### PR TITLE
[pkg/sitemap-ext]: Fixes `trailingSlash` handling for SSR dynamic routes

### DIFF
--- a/.changeset/shaggy-bobcats-type.md
+++ b/.changeset/shaggy-bobcats-type.md
@@ -1,0 +1,5 @@
+---
+"@inox-tools/sitemap-ext": patch
+---
+
+Fixes generation of dynamic SSR URLs to behave the same as the official sitemap integration regarding `trailingSlash` configuration

--- a/packages/sitemap-ext/index.ts
+++ b/packages/sitemap-ext/index.ts
@@ -70,11 +70,14 @@ export default defineIntegration({
 
 		const extraPages: string[] = [...(_externalPages ?? [])];
 
+		let trailingSlash = false;
+
 		let baseUrl!: URL;
 
 		return {
 			'astro:config:setup': (params) => {
 				const { defineRouteConfig, logger, config } = params;
+				trailingSlash = config.trailingSlash !== 'never';
 
 				if (hasIntegration(params, { name: '@astrojs/sitemap' })) {
 					throw new AstroError(
@@ -169,7 +172,8 @@ export default defineIntegration({
 				}
 
 				for (const page of extraPagesSet) {
-					extraPages.push(new URL(page, baseUrl).toString());
+					const url = trimSlashes(new URL(page, baseUrl).toString());
+					extraPages.push(trailingSlash ? url + '/' : url);
 				}
 			},
 		};


### PR DESCRIPTION
- Fixes #64 