### PR TITLE
Fix manually defining injected collections

### DIFF
--- a/packages/content-utils/src/runtime/injector.ts
+++ b/packages/content-utils/src/runtime/injector.ts
@@ -43,8 +43,6 @@ export function injectCollections(
 	const resolvedCollections: Record<string, CollectionConfig> = {};
 
 	for (const [key, value] of Object.entries(combinedCollections)) {
-		if (collections[key] !== undefined) continue;
-
 		resolvedCollections[key] = isFancyCollection(value) ? value() : value;
 	}
 


### PR DESCRIPTION
If a injected collection is defined manually, ex:

```ts
export const collections = {
	integrationDocs: integrationCollections.integrationDocs({
		extends: ({ image }) =>
			z.object({
				card: image(),
			}),
	}),
};
```

It does not get resolved