### PR TITLE
fix(aik-route-config): Fixed compatibility with compiler v2.8

### DIFF
--- a/.changeset/empty-geese-eat.md
+++ b/.changeset/empty-geese-eat.md
@@ -1,0 +1,7 @@
+---
+'@inox-tools/aik-route-config': patch
+---
+
+Fixes hoisting for routes not using the global `Astro` variable.
+
+When an Astro component doesn't use the `Astro` variable anywhere the `$$createAstro` call is not emmited in the compiled source (https://github.com/withastro/compiler/commit/e8b6cdfc89f940a411304787632efd8140535feb). In that case use the `$$createComponent` call as hoisting anchor instead.

--- a/packages/aik-route-config/__tests__/hoist.test.ts
+++ b/packages/aik-route-config/__tests__/hoist.test.ts
@@ -26,51 +26,44 @@ test('hoist simple call', async () => {
 	});
 
 	expect(result?.code).toMatchInlineSnapshot(`
-    "import {
-      Fragment,
-      render as $$render,
-      createAstro as $$createAstro,
-      createComponent as $$createComponent,
-      renderComponent as $$renderComponent,
-      renderHead as $$renderHead,
-      maybeRenderHead as $$maybeRenderHead,
-      unescapeHTML as $$unescapeHTML,
-      renderSlot as $$renderSlot,
-      mergeSlots as $$mergeSlots,
-      addAttribute as $$addAttribute,
-      spreadAttributes as $$spreadAttributes,
-      defineStyleVars as $$defineStyleVars,
-      defineScriptVars as $$defineScriptVars,
-      renderTransition as $$renderTransition,
-      createTransitionScope as $$createTransitionScope,
-      renderScript as $$renderScript,
-      createMetadata as $$createMetadata
-    } from "astro/runtime/server/index.js";
-    import customName from 'magic:hoist';
+		"import {
+		  Fragment,
+		  render as $$render,
+		  createAstro as $$createAstro,
+		  createComponent as $$createComponent,
+		  renderComponent as $$renderComponent,
+		  renderHead as $$renderHead,
+		  maybeRenderHead as $$maybeRenderHead,
+		  unescapeHTML as $$unescapeHTML,
+		  renderSlot as $$renderSlot,
+		  mergeSlots as $$mergeSlots,
+		  addAttribute as $$addAttribute,
+		  spreadAttributes as $$spreadAttributes,
+		  defineStyleVars as $$defineStyleVars,
+		  defineScriptVars as $$defineScriptVars,
+		  renderTransition as $$renderTransition,
+		  createTransitionScope as $$createTransitionScope,
+		  renderScript as $$renderScript,
+		  createMetadata as $$createMetadata
+		} from "astro/runtime/server/index.js";
+		import customName from 'magic:hoist';
 
 
-    import * as $$module1 from 'magic:hoist';
+		import * as $$module1 from 'magic:hoist';
 
-    export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'magic:hoist', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+		export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'magic:hoist', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-    const $$Astro = $$createAstro();
+		await customName({
+		  bundleFile: import.meta.url,
+		  sourceFile: "/src/pages/simple.astro"
+		}, 'hosted value');
 
-    await customName({
-      bundleFile: import.meta.url,
-      sourceFile: "/src/pages/simple.astro"
-    }, 'hosted value');
-
-    const Astro = $$Astro;
-    const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
-      const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-      Astro.self = $$stdin;
-
-
-      return $$render\`\${$$maybeRenderHead($$result)}<p>Simple page</p>\`;
-    }, '<stdin>', undefined);
-    export default $$stdin;
-    "
-  `);
+		const $$stdin = $$createComponent(($$result, $$props, $$slots) => {
+		  return $$render\`\${$$maybeRenderHead($$result)}<p>Simple page</p>\`;
+		}, '<stdin>', undefined);
+		export default $$stdin;
+		"
+	`);
 });
 
 test('hoist awaited call', async () => {
@@ -84,51 +77,44 @@ test('hoist awaited call', async () => {
 	});
 
 	expect(result?.code).toMatchInlineSnapshot(`
-    "import {
-      Fragment,
-      render as $$render,
-      createAstro as $$createAstro,
-      createComponent as $$createComponent,
-      renderComponent as $$renderComponent,
-      renderHead as $$renderHead,
-      maybeRenderHead as $$maybeRenderHead,
-      unescapeHTML as $$unescapeHTML,
-      renderSlot as $$renderSlot,
-      mergeSlots as $$mergeSlots,
-      addAttribute as $$addAttribute,
-      spreadAttributes as $$spreadAttributes,
-      defineStyleVars as $$defineStyleVars,
-      defineScriptVars as $$defineScriptVars,
-      renderTransition as $$renderTransition,
-      createTransitionScope as $$createTransitionScope,
-      renderScript as $$renderScript,
-      createMetadata as $$createMetadata
-    } from "astro/runtime/server/index.js";
-    import customName from 'magic:hoist';
+		"import {
+		  Fragment,
+		  render as $$render,
+		  createAstro as $$createAstro,
+		  createComponent as $$createComponent,
+		  renderComponent as $$renderComponent,
+		  renderHead as $$renderHead,
+		  maybeRenderHead as $$maybeRenderHead,
+		  unescapeHTML as $$unescapeHTML,
+		  renderSlot as $$renderSlot,
+		  mergeSlots as $$mergeSlots,
+		  addAttribute as $$addAttribute,
+		  spreadAttributes as $$spreadAttributes,
+		  defineStyleVars as $$defineStyleVars,
+		  defineScriptVars as $$defineScriptVars,
+		  renderTransition as $$renderTransition,
+		  createTransitionScope as $$createTransitionScope,
+		  renderScript as $$renderScript,
+		  createMetadata as $$createMetadata
+		} from "astro/runtime/server/index.js";
+		import customName from 'magic:hoist';
 
 
-    import * as $$module1 from 'magic:hoist';
+		import * as $$module1 from 'magic:hoist';
 
-    export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'magic:hoist', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+		export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'magic:hoist', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-    const $$Astro = $$createAstro();
+		await customName({
+		  bundleFile: import.meta.url,
+		  sourceFile: "/src/pages/simple.astro"
+		}, 'hosted value');
 
-    await customName({
-      bundleFile: import.meta.url,
-      sourceFile: "/src/pages/simple.astro"
-    }, 'hosted value');
-
-    const Astro = $$Astro;
-    const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
-      const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-      Astro.self = $$stdin;
-
-
-      return $$render\`\${$$maybeRenderHead($$result)}<p>Simple page</p>\`;
-    }, '<stdin>', undefined);
-    export default $$stdin;
-    "
-  `);
+		const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
+		  return $$render\`\${$$maybeRenderHead($$result)}<p>Simple page</p>\`;
+		}, '<stdin>', undefined);
+		export default $$stdin;
+		"
+	`);
 });
 
 test('hoist calls mixed with other exports and scopes', async () => {
@@ -142,68 +128,62 @@ test('hoist calls mixed with other exports and scopes', async () => {
 	});
 
 	expect(result?.code).toMatchInlineSnapshot(`
-    "import {
-      Fragment,
-      render as $$render,
-      createAstro as $$createAstro,
-      createComponent as $$createComponent,
-      renderComponent as $$renderComponent,
-      renderHead as $$renderHead,
-      maybeRenderHead as $$maybeRenderHead,
-      unescapeHTML as $$unescapeHTML,
-      renderSlot as $$renderSlot,
-      mergeSlots as $$mergeSlots,
-      addAttribute as $$addAttribute,
-      spreadAttributes as $$spreadAttributes,
-      defineStyleVars as $$defineStyleVars,
-      defineScriptVars as $$defineScriptVars,
-      renderTransition as $$renderTransition,
-      createTransitionScope as $$createTransitionScope,
-      renderScript as $$renderScript,
-      createMetadata as $$createMetadata
-    } from "astro/runtime/server/index.js";
-    import customName from 'magic:hoist';
+		"import {
+		  Fragment,
+		  render as $$render,
+		  createAstro as $$createAstro,
+		  createComponent as $$createComponent,
+		  renderComponent as $$renderComponent,
+		  renderHead as $$renderHead,
+		  maybeRenderHead as $$maybeRenderHead,
+		  unescapeHTML as $$unescapeHTML,
+		  renderSlot as $$renderSlot,
+		  mergeSlots as $$mergeSlots,
+		  addAttribute as $$addAttribute,
+		  spreadAttributes as $$spreadAttributes,
+		  defineStyleVars as $$defineStyleVars,
+		  defineScriptVars as $$defineScriptVars,
+		  renderTransition as $$renderTransition,
+		  createTransitionScope as $$createTransitionScope,
+		  renderScript as $$renderScript,
+		  createMetadata as $$createMetadata
+		} from "astro/runtime/server/index.js";
+		import customName from 'magic:hoist';
 
 
-    import * as $$module1 from 'magic:hoist';
+		import * as $$module1 from 'magic:hoist';
 
-    export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'magic:hoist', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+		export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'magic:hoist', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-    const $$Astro = $$createAstro();
+		export function getStaticPaths() {
+			customName({
+		        bundleFile: import.meta.url,
+		        sourceFile: "/src/pages/simple.astro"
+		    }, 'should be extended in-place');
+			return [];
+		}
 
-    await customName({
-        bundleFile: import.meta.url,
-        sourceFile: "/src/pages/simple.astro"
-    }, 'hoisted value');
+		await customName({
+		    bundleFile: import.meta.url,
+		    sourceFile: "/src/pages/simple.astro"
+		}, 'hoisted value');
 
-    await customName({
-        bundleFile: import.meta.url,
-        sourceFile: "/src/pages/simple.astro"
-    }, 'second hoisted value');
+		await customName({
+		    bundleFile: import.meta.url,
+		    sourceFile: "/src/pages/simple.astro"
+		}, 'second hoisted value');
 
-    const Astro = $$Astro;
-    export function getStaticPaths() {
-    	customName({
-            bundleFile: import.meta.url,
-            sourceFile: "/src/pages/simple.astro"
-        }, 'should be extended in-place');
-    	return [];
-    }
-    const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
-        const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-        Astro.self = $$stdin;
-
-
-        function notExported() {
-            void 0;
-        }
+		const $$stdin = $$createComponent(($$result, $$props, $$slots) => {
+		    function notExported() {
+		        void 0;
+		    }
 
 
-        return $$render\`\${$$maybeRenderHead($$result)}<p>Simple page</p>\`;
-    }, '<stdin>', undefined);
-    export default $$stdin;
-    "
-  `);
+		    return $$render\`\${$$maybeRenderHead($$result)}<p>Simple page</p>\`;
+		}, '<stdin>', undefined);
+		export default $$stdin;
+		"
+	`);
 });
 
 test('hoist calls mixed with adversary exports', async () => {
@@ -256,24 +236,18 @@ test('hoist calls mixed with adversary exports', async () => {
 
 		export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'magic:hoist', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-		const $$Astro = $$createAstro();
+		export function getStaticPaths() {
+			const bar: string[] = [];
+
+			return bar.map((x) => x);
+		}
 
 		await customName({
 		  bundleFile: import.meta.url,
 		  sourceFile: "/src/pages/simple.astro"
 		}, 'second hoisted value');
 
-		const Astro = $$Astro;
-		export function getStaticPaths() {
-			const bar: string[] = [];
-
-			return bar.map((x) => x);
-		}
-		const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
-		  const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-		  Astro.self = $$stdin;
-
-
+		const $$stdin = $$createComponent(($$result, $$props, $$slots) => {
 		  const foo: string[] = $$createComponent([]);
 
 

--- a/packages/aik-route-config/__tests__/scriptBlocks.test.ts
+++ b/packages/aik-route-config/__tests__/scriptBlocks.test.ts
@@ -13,70 +13,64 @@ test('ignore script blocks', async () => {
 	});
 
 	expect(result?.code).toMatchInlineSnapshot(`
-    "import {
-      Fragment,
-      render as $$render,
-      createAstro as $$createAstro,
-      createComponent as $$createComponent,
-      renderComponent as $$renderComponent,
-      renderHead as $$renderHead,
-      maybeRenderHead as $$maybeRenderHead,
-      unescapeHTML as $$unescapeHTML,
-      renderSlot as $$renderSlot,
-      mergeSlots as $$mergeSlots,
-      addAttribute as $$addAttribute,
-      spreadAttributes as $$spreadAttributes,
-      defineStyleVars as $$defineStyleVars,
-      defineScriptVars as $$defineScriptVars,
-      renderTransition as $$renderTransition,
-      createTransitionScope as $$createTransitionScope,
-      renderScript as $$renderScript,
-      createMetadata as $$createMetadata
-    } from "astro/runtime/server/index.js";
-    import { t } from 'i18n:astro';
-    import Layout from '~/layouts/Layout.astro';
-    import sitemap from 'i18n:astro/sitemap';
+		"import {
+		  Fragment,
+		  render as $$render,
+		  createAstro as $$createAstro,
+		  createComponent as $$createComponent,
+		  renderComponent as $$renderComponent,
+		  renderHead as $$renderHead,
+		  maybeRenderHead as $$maybeRenderHead,
+		  unescapeHTML as $$unescapeHTML,
+		  renderSlot as $$renderSlot,
+		  mergeSlots as $$mergeSlots,
+		  addAttribute as $$addAttribute,
+		  spreadAttributes as $$spreadAttributes,
+		  defineStyleVars as $$defineStyleVars,
+		  defineScriptVars as $$defineScriptVars,
+		  renderTransition as $$renderTransition,
+		  createTransitionScope as $$createTransitionScope,
+		  renderScript as $$renderScript,
+		  createMetadata as $$createMetadata
+		} from "astro/runtime/server/index.js";
+		import { t } from 'i18n:astro';
+		import Layout from '~/layouts/Layout.astro';
+		import sitemap from 'i18n:astro/sitemap';
 
 
-    import * as $$module1 from 'i18n:astro';
-    import * as $$module2 from '~/layouts/Layout.astro';
-    import * as $$module3 from 'i18n:astro/sitemap';
-    import * as $$module4 from 'i18n:astro';
+		import * as $$module1 from 'i18n:astro';
+		import * as $$module2 from '~/layouts/Layout.astro';
+		import * as $$module3 from 'i18n:astro/sitemap';
+		import * as $$module4 from 'i18n:astro';
 
-    export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'i18n:astro', assert: {} }, { module: $$module2, specifier: '~/layouts/Layout.astro', assert: {} }, { module: $$module3, specifier: 'i18n:astro/sitemap', assert: {} }, { module: $$module4, specifier: 'i18n:astro', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [{ type: 'inline', value: \`
-    		import { t } from 'i18n:astro';
+		export const $$metadata = $$createMetadata("<stdin>", { modules: [{ module: $$module1, specifier: 'i18n:astro', assert: {} }, { module: $$module2, specifier: '~/layouts/Layout.astro', assert: {} }, { module: $$module3, specifier: 'i18n:astro/sitemap', assert: {} }, { module: $$module4, specifier: 'i18n:astro', assert: {} }], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [{ type: 'inline', value: \`
+				import { t } from 'i18n:astro';
 
-    		document.getElementById('span')!.innerHTML = t('about');
-    	\` }] });
+				document.getElementById('span')!.innerHTML = t('about');
+			\` }] });
 
-    const $$Astro = $$createAstro();
+		await sitemap({
+		    bundleFile: import.meta.url,
+		    sourceFile: "/src/pages/index.astro"
+		}, 'TEST');
 
-    await sitemap({
-        bundleFile: import.meta.url,
-        sourceFile: "/src/pages/index.astro"
-    }, 'TEST');
-
-    const Astro = $$Astro;
-    const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
-        const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-        Astro.self = $$stdin;
-
-        // From:
-        // https://github.com/astrolicious/i18n/blob/a69646636ad32e42620b240fe50dff7476ab6606/playground/src/routes/index.astro
+		const $$stdin = $$createComponent(($$result, $$props, $$slots) => {
+		    // From:
+		    // https://github.com/astrolicious/i18n/blob/a69646636ad32e42620b240fe50dff7476ab6606/playground/src/routes/index.astro
 
 
 
-        const title = t('home:title');
+		    const title = t('home:title');
 
 
-        return $$render\`\${$$renderComponent($$result,'Layout',Layout,{"title":(title)},{"default": () => $$render\`
-            \${$$maybeRenderHead($$result)}<h1>\${title}</h1>
-            <p>\${t('home:description', { value: '9' })}</p>
-            <span id="span"></span>
-            
-        \`,})}\`;
-    }, '<stdin>', undefined);
-    export default $$stdin;
-    "
-  `);
+		    return $$render\`\${$$renderComponent($$result,'Layout',Layout,{"title":(title)},{"default": () => $$render\`
+		        \${$$maybeRenderHead($$result)}<h1>\${title}</h1>
+		        <p>\${t('home:description', { value: '9' })}</p>
+		        <span id="span"></span>
+		        
+		    \`,})}\`;
+		}, '<stdin>', undefined);
+		export default $$stdin;
+		"
+	`);
 });

--- a/packages/aik-route-config/vitest.config.ts
+++ b/packages/aik-route-config/vitest.config.ts
@@ -7,10 +7,10 @@ export default defineConfig({
 			reportsDirectory: './__coverage__',
 			thresholds: {
 				autoUpdate: true,
-				lines: 51.45,
+				lines: 52.32,
 				functions: 71.42,
-				branches: 82.14,
-				statements: 51.45,
+				branches: 82.75,
+				statements: 52.32,
 			},
 		},
 	},


### PR DESCRIPTION
When an Astro component doesn't use the `Astro` variable anywhere the `$$createAstro` call is not emmited in the compiled source (https://github.com/withastro/compiler/commit/e8b6cdfc89f940a411304787632efd8140535feb). In that case use the `$$createComponent` call as hoisting anchor instead.
