### PR TITLE
chore(modular-station): Future-proof hook handling

### DIFF
--- a/.changeset/swift-wolves-hug.md
+++ b/.changeset/swift-wolves-hug.md
@@ -2,4 +2,4 @@
 '@inox-tools/modular-station': patch
 ---
 
-Extends API and hooks functionality to unnoficial hooks and future hooks
+Extends API and hooks functionality to unofficial hooks and future hooks

--- a/.changeset/swift-wolves-hug.md
+++ b/.changeset/swift-wolves-hug.md
@@ -1,0 +1,5 @@
+---
+'@inox-tools/modular-station': patch
+---
+
+Extends API and hooks functionality to unnoficial hooks and future hooks

--- a/packages/modular-station/src/allHooksPlugin.ts
+++ b/packages/modular-station/src/allHooksPlugin.ts
@@ -1,0 +1,55 @@
+import { definePlugin, type Plugin, type Hooks } from 'astro-integration-kit';
+
+export const DEFAULT_HOOK_FACTORY: unique symbol = Symbol(
+	'@inox-tools/modular-station:allHooksPlugin/default'
+);
+
+export type HookNames = keyof Hooks;
+
+export type PluginSetup<TApi extends Record<string, unknown>> = {
+	[Hook in keyof Hooks]?: (...params: Parameters<Hooks[Hook]>) => TApi;
+} & {
+	[DEFAULT_HOOK_FACTORY]: <H extends keyof Hooks>(
+		name: H
+	) => (...params: Parameters<Hooks[H]>) => TApi;
+};
+
+export type AllHooksPluginDefinition<TName extends string, TApi extends Record<string, unknown>> = {
+	name: TName;
+	setup: (params: { name: string }) => PluginSetup<TApi>;
+};
+
+export type AllHooksPlugin<TName extends string, TApi extends Record<string, unknown>> = Plugin<
+	TName,
+	Record<keyof Hooks, TApi>
+>;
+
+/**
+ * Allows defining a type-safe plugin that can be used from any Astro hook.
+ *
+ * This is a wrapper over Astro Integration Kit's {@link definePlugin} that
+ * automatically extends your plugin definition for any integration-defined
+ * hook or future Astro hook.
+ *
+ * @see https://astro-integration-kit.netlify.app/utilities/define-plugin/
+ */
+export const allHooksPlugin = <TName extends string, TApi extends Record<string, unknown>>(
+	plugin: AllHooksPluginDefinition<TName, TApi>
+): AllHooksPlugin<TName, TApi> =>
+	definePlugin({
+		...plugin,
+		setup: (params) => {
+			const { [DEFAULT_HOOK_FACTORY]: defaultHookFactory, ...hooks } = plugin.setup(params);
+
+			return new Proxy(hooks as ReturnType<Plugin<any, any>['setup']>, {
+				// Has any key
+				has: (target, prop) => typeof prop === 'string' || Reflect.has(target, prop),
+				get: (target, prop, receiver) => {
+					const realHook = Reflect.get(target, prop, receiver);
+					if (realHook !== undefined || typeof prop !== 'string') return realHook;
+
+					return defaultHookFactory(prop as keyof Hooks);
+				},
+			});
+		},
+	});

--- a/packages/modular-station/src/hooks.ts
+++ b/packages/modular-station/src/hooks.ts
@@ -1,5 +1,5 @@
 import type { AstroIntegration } from 'astro';
-import { definePlugin } from 'astro-integration-kit';
+import { DEFAULT_HOOK_FACTORY, allHooksPlugin } from './allHooksPlugin.js';
 
 export type AsyncHooks = {
 	[K in keyof Required<AstroLibs.Hooks>]: NonNullable<AstroLibs.Hooks[K]> extends (
@@ -58,7 +58,7 @@ export interface PluginApi {
 	execLibHookSync<K extends SyncHooks>(hook: K, ...params: Parameters<AstroLibs.Hooks[K]>): void;
 }
 
-export const hookProviderPlugin = definePlugin({
+export const hookProviderPlugin = allHooksPlugin({
 	name: 'hook-provider',
 	setup() {
 		let integrations: AstroIntegration[];
@@ -79,14 +79,7 @@ export const hookProviderPlugin = definePlugin({
 
 				return pluginApi;
 			},
-			'astro:build:setup': () => pluginApi,
-			'astro:build:start': () => pluginApi,
-			'astro:build:ssr': () => pluginApi,
-			'astro:build:done': () => pluginApi,
-			'astro:build:generated': () => pluginApi,
-			'astro:server:setup': () => pluginApi,
-			'astro:server:start': () => pluginApi,
-			'astro:server:done': () => pluginApi,
+			[DEFAULT_HOOK_FACTORY]: () => () => pluginApi,
 		};
 	},
 });


### PR DESCRIPTION
Extends the implementation of the modular-station hooks and API to extend to any hook dynamically.

The main change for now is that integration APIs and hooks will be available on Astro DB hooks as well, but other things are soon to come that will make this even more interesting.