### PR TITLE
docs(portal-gun): fix typo

### DIFF
--- a/docs/src/content/docs/portal-gun.mdx
+++ b/docs/src/content/docs/portal-gun.mdx
@@ -51,7 +51,7 @@ Given the following document:
 <portal-gate to="start:#element-id">
 	<p>Before</p>
 </portal-gate>
-<portal-gate to="after:#element-id">
+<portal-gate to="end:#element-id">
 	<p>After</p>
 </portal-gate>
 ```


### PR DESCRIPTION
Hi Luiz 👋🏼, the docs also mention `after:` instead of `end:`.

I was wondering whether that happend, because you already thought about widening this to `before` and `after` like `insertAdjacentElement()` supports beforebegin, afterbegin, beforeand and afterend?
