### PR TITLE
fix(runtime-logger): Use unique names for internal plugins

### DIFF
--- a/.changeset/many-poems-greet.md
+++ b/.changeset/many-poems-greet.md
@@ -1,0 +1,5 @@
+---
+'@inox-tools/runtime-logger': patch
+---
+
+Fixes internal plugins having the same name causing incorrect warnings when building

--- a/packages/runtime-logger/src/buildLoggerPlugin.ts
+++ b/packages/runtime-logger/src/buildLoggerPlugin.ts
@@ -5,7 +5,7 @@ import { INTERNAL_MODULE } from './internalPlugin.js';
 const MODULE_PREFIX = '@it-astro:logger:';
 const RESOLVED_MODULE_PREFIX = '\x00@it-astro:logger:';
 
-const pluginName = '@inox-tools/runtime-logger/dev';
+const pluginName = '@inox-tools/runtime-logger/integrations';
 
 export const buildLoggerPlugin = (loggers: Map<string, AstroIntegrationLogger>): Plugin => {
 	(globalThis as any)[Symbol.for(pluginName)] = loggers;

--- a/packages/runtime-logger/src/devLoggerPlugin.ts
+++ b/packages/runtime-logger/src/devLoggerPlugin.ts
@@ -4,7 +4,7 @@ import type { AstroIntegrationLogger } from 'astro';
 const MODULE_PREFIX = '@it-astro:logger:';
 const RESOLVED_MODULE_PREFIX = '\x00@it-astro:logger:';
 
-const pluginName = '@inox-tools/runtime-logger/dev';
+const pluginName = '@inox-tools/runtime-logger/integrations';
 
 export const devLoggerPlugin = (loggers: Map<string, AstroIntegrationLogger>): Plugin => {
 	(globalThis as any)[Symbol.for(pluginName)] = loggers;

--- a/packages/runtime-logger/src/projectLoggerPlugin.ts
+++ b/packages/runtime-logger/src/projectLoggerPlugin.ts
@@ -5,7 +5,7 @@ const VIRTUAL_MODULE = '@it-astro:logger';
 const RESOLVED_VIRTUAL_MODULE = '\x00@it-astro:logger?';
 
 export const projectLoggerPlugin = (rootPath: string): Plugin => ({
-	name: '@inox-tools/runtime-logger/dev',
+	name: '@inox-tools/runtime-logger/project',
 	resolveId(id, importer) {
 		if (id === VIRTUAL_MODULE) {
 			const params = new URLSearchParams();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved issues with incorrect build warnings caused by internal plugins with identical names.
  
- **New Features**
	- Updated plugin names for better clarity and identification:
		- `@inox-tools/runtime-logger/dev` changed to `@inox-tools/runtime-logger/integrations`.
		- `@inox-tools/runtime-logger/dev` changed to `@inox-tools/runtime-logger/project`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->