### PR TITLE
feat(content-utils): Add Git support for Content Layer

### DIFF
--- a/.changeset/long-lamps-move.md
+++ b/.changeset/long-lamps-move.md
@@ -1,0 +1,7 @@
+---
+'@inox-tools/content-utils': patch
+---
+
+Adds support for Git information associated with entries using Content Layer loaders instead of only legacy collections.
+
+Works with any loader that populates `filePath` referring to a file within the project tree.

--- a/.changeset/long-lamps-move.md
+++ b/.changeset/long-lamps-move.md
@@ -3,5 +3,6 @@
 ---
 
 Adds support for Git information associated with entries using Content Layer loaders instead of only legacy collections.
+Previously, git information was only available for collection entries made using the legacy behavior and only from the `src/content` directory.
 
-Works with any loader that populates `filePath` referring to a file within the project tree.
+Now it is available for collection entries made from any loader that populates `filePath` referring to a file within the project tree (within the direction containing the Astro config file).

--- a/packages/content-utils/src/integration/gitPlugin.ts
+++ b/packages/content-utils/src/integration/gitPlugin.ts
@@ -1,10 +1,16 @@
 import type { Plugin } from 'vite';
 import type { IntegrationState } from './state.js';
 import * as liveGit from '../runtime/git.js';
+import * as devalue from 'devalue';
+import { join as joinPath } from 'node:path';
 import { getDebug } from '../internal/debug.js';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 const MODULE_ID = '@it-astro:content/git';
 const RESOLVED_MODULE_ID = '\x00@it-astro:content/git';
+
+const INNER_MODULE_ID = '@it-astro:content/git/internal';
+const RESOLVED_INNER_MODULE_ID = '\x00@it-astro:content/git/internal';
 
 const debug = getDebug('git-time-plugin');
 
@@ -30,23 +36,102 @@ setProjectRoot(${JSON.stringify(projectRoot)});
 	},
 });
 
-export const gitBuildPlugin = ({ contentPaths: { projectRoot } }: IntegrationState): Plugin => ({
-	name: '@inox-tools/content-utils/gitTimes',
-	resolveId(id) {
-		if (id === MODULE_ID) return RESOLVED_MODULE_ID;
-	},
-	async load(id, { ssr } = {}) {
-		if (id !== RESOLVED_MODULE_ID || !ssr) return;
+export const gitBuildPlugin = (state: IntegrationState): Plugin => {
+	const {
+		contentPaths: { projectRoot },
+	} = state;
 
-		debug('Registering project root:', projectRoot);
-		liveGit.setProjectRoot(projectRoot);
-		const trackedFiles = await liveGit.collectGitInfoForContentFiles();
-		debug('Git tracked file dates:', trackedFiles);
+	return {
+		name: '@inox-tools/content-utils/gitTimes',
+		resolveId(id) {
+			if (id === MODULE_ID) return RESOLVED_MODULE_ID;
+			if (id === INNER_MODULE_ID) return RESOLVED_INNER_MODULE_ID;
+		},
+		writeBundle(info, bundle) {
+			if (!info.dir) return;
+			let contentDataEntrypoint: string | undefined;
+			let gitStateEntrypoint: string | undefined;
+			for (const chunk of Object.values(bundle)) {
+				if (chunk.type !== 'chunk') continue;
+				if (chunk.moduleIds.length !== 1) continue;
 
-		return `
+				switch (chunk.moduleIds[0]) {
+					case RESOLVED_INNER_MODULE_ID:
+						gitStateEntrypoint = joinPath(info.dir, chunk.fileName);
+					case '\0astro:data-layer-content':
+						contentDataEntrypoint = joinPath(info.dir, chunk.fileName);
+				}
+			}
+
+			if (contentDataEntrypoint && gitStateEntrypoint) {
+				state.cleanups.push(() => cleanupState(contentDataEntrypoint, gitStateEntrypoint));
+			}
+		},
+		async load(id, { ssr } = {}) {
+			if (!ssr) return;
+
+			if (id === RESOLVED_MODULE_ID) return buildFacade;
+
+			if (id === RESOLVED_INNER_MODULE_ID) {
+				debug('Registering project root:', projectRoot);
+				liveGit.setProjectRoot(projectRoot);
+				const trackedFiles = await liveGit.collectGitInfoForContentFiles();
+				debug('Git tracked file dates:', trackedFiles);
+
+				return `const trackedFiles = ${devalue.stringify(new Map(trackedFiles))};
+export { trackedFiles as default };`;
+			}
+		},
+	};
+};
+
+async function cleanupState(contentData: string, gitState: string): Promise<void> {
+	if (!existsSync(contentData) || !existsSync(gitState)) return;
+
+	const originalContent = readFileSync(gitState, 'utf-8');
+
+	// Content was already cleared by Astro. Collections are not used anywhere on server bundle
+	if (!originalContent.includes('export')) return;
+
+	// Import the chunk, which exports a devalue flattened map as the default export
+	const { default: contentValue } = await import(/*@vite-ignore*/ contentData);
+	const { default: gitValue } = await import(/*@vite-ignore*/ gitState);
+
+	// Unflatten the map
+	const contentMap: Map<string, Map<string, unknown>> = devalue.unflatten(contentValue);
+	const gitInformation: Map<string, unknown> = devalue.unflatten(gitValue);
+
+	const usedFiles = new Set();
+
+	// Extract all files that are used by the content layer
+	for (const collection of contentMap.values()) {
+		for (const entry of collection.values()) {
+			if (typeof entry === 'object' && entry && 'filePath' in entry && entry.filePath) {
+				usedFiles.add(entry.filePath);
+			}
+		}
+	}
+
+	// Build a reduced map including only the used files
+	const cleanedMap = new Map(
+		Array.from(gitInformation.entries()).filter(([path]) => usedFiles.has(path))
+	);
+
+	// Build the source code with the new map flattened
+	const newContent = [
+		`const trackedFiles = ${devalue.stringify(cleanedMap)}`,
+		'\nexport { trackedFiles as default }',
+	].join('\n');
+
+	// Write it back
+	writeFileSync(gitState, newContent, 'utf-8');
+}
+
+const buildFacade = `
 import {getEntry} from 'astro:content';
+import {unflatten} from ${JSON.stringify(import.meta.resolve('devalue'))};
 
-const trackedFiles = new Map(${JSON.stringify(trackedFiles)});
+const trackedFiles = unflatten((await import(${JSON.stringify(INNER_MODULE_ID)})).default);
 
 export async function getEntryGitInfo(...args) {
 	const params = args.length > 1 ? args : [args[0].collection, args[0].slug ?? args[0].id];
@@ -62,11 +147,10 @@ export async function getEntryGitInfo(...args) {
 	};
 }
 
-const latestCommits = new Map([
-${trackedFiles
-				.map(([file, fileInfo]) => `[${JSON.stringify(file)}, new Date(${fileInfo.latest.valueOf()})]`)
-				.join(',')}
-]);
+const latestCommits = new Map(
+	Array.from(trackedFiles.entries())
+		.map(([file, fileInfo]) => [file, new Date(fileInfo.latest)])
+);
 
 export async function getLatestCommitDate(...args) {
 	const params = args.length > 1 ? args : [args[0].collection, args[0].slug ?? args[0].id];
@@ -80,11 +164,10 @@ export async function getLatestCommitDate(...args) {
   return now;
 }
 
-const oldestCommits = new Map([
-${trackedFiles
-				.map(([file, fileInfo]) => `[${JSON.stringify(file)}, new Date(${fileInfo.earliest.valueOf()})]`)
-				.join(',')}
-]);
+const oldestCommits = new Map(
+	Array.from(trackedFiles.entries())
+		.map(([file, fileInfo]) => [file, new Date(fileInfo.earliest)])
+);
 
 export async function getOldestCommitDate(...args) {
 	const params = args.length > 1 ? args : [args[0].collection, args[0].slug ?? args[0].id];
@@ -98,5 +181,3 @@ export async function getOldestCommitDate(...args) {
   return now;
 }
 `;
-	},
-});

--- a/packages/content-utils/src/integration/gitPlugin.ts
+++ b/packages/content-utils/src/integration/gitPlugin.ts
@@ -156,8 +156,7 @@ export async function getLatestCommitDate(...args) {
 	const params = args.length > 1 ? args : [args[0].collection, args[0].slug ?? args[0].id];
 	const entry = await getEntry(...params);
 
-	const file = \`\${entry.collection}:\${entry.filePath}\`;
-  const cached = latestCommits.get(file);
+  const cached = latestCommits.get(entry.filePath);
   if (cached !== undefined) return cached;
   const now = new Date();
   latestCommits.set(file, now);
@@ -173,8 +172,7 @@ export async function getOldestCommitDate(...args) {
 	const params = args.length > 1 ? args : [args[0].collection, args[0].slug ?? args[0].id];
 	const entry = await getEntry(...params);
 
-	const file = \`\${entry.collection}:\${entry.id}\`;
-  const cached = oldestCommits.get(file);
+  const cached = oldestCommits.get(entry.filePath);
   if (cached !== undefined) return cached;
   const now = new Date();
   oldestCommits.set(file, now);

--- a/packages/content-utils/src/integration/gitPlugin.ts
+++ b/packages/content-utils/src/integration/gitPlugin.ts
@@ -58,8 +58,10 @@ export const gitBuildPlugin = (state: IntegrationState): Plugin => {
 				switch (chunk.moduleIds[0]) {
 					case RESOLVED_INNER_MODULE_ID:
 						gitStateEntrypoint = joinPath(info.dir, chunk.fileName);
+						break;
 					case '\0astro:data-layer-content':
 						contentDataEntrypoint = joinPath(info.dir, chunk.fileName);
+						break;
 				}
 			}
 
@@ -159,7 +161,7 @@ export async function getLatestCommitDate(...args) {
   const cached = latestCommits.get(entry.filePath);
   if (cached !== undefined) return cached;
   const now = new Date();
-  latestCommits.set(file, now);
+  latestCommits.set(entry.filePath, now);
   return now;
 }
 
@@ -175,7 +177,7 @@ export async function getOldestCommitDate(...args) {
   const cached = oldestCommits.get(entry.filePath);
   if (cached !== undefined) return cached;
   const now = new Date();
-  oldestCommits.set(file, now);
+  oldestCommits.set(entry.filePath, now);
   return now;
 }
 `;

--- a/packages/content-utils/src/integration/index.ts
+++ b/packages/content-utils/src/integration/index.ts
@@ -110,6 +110,9 @@ export const integration = withApi(
 					},
 					'astro:build:done': async () => {
 						await clearStaticCollections(state);
+						for (const cleanup of state.cleanups) {
+							await cleanup();
+						}
 					},
 				},
 				...api,

--- a/packages/content-utils/src/integration/state.ts
+++ b/packages/content-utils/src/integration/state.ts
@@ -7,11 +7,13 @@ export interface IntegrationState {
 	staticOnlyCollections: string[];
 	contentPaths: ResolvedContentPaths;
 	contentDataEntrypoint?: string;
+	cleanups: (() => Promise<void>)[];
 }
 
 export function emptyState(): IntegrationState {
 	return {
 		injectedCollectionsEntrypoints: [],
 		staticOnlyCollections: [],
+		cleanups: [],
 	} as Partial<IntegrationState> as IntegrationState;
 }

--- a/packages/content-utils/src/internal/resolver.ts
+++ b/packages/content-utils/src/internal/resolver.ts
@@ -16,6 +16,7 @@ const possibleConfigs = [
 ];
 
 export type ResolvedContentPaths = {
+	projectRoot: string;
 	contentPath: string;
 	configPath: string;
 	configExists: boolean;
@@ -37,6 +38,7 @@ export function resolveContentPaths(config: AstroConfig): ResolvedContentPaths {
 	const configFile = existingConfig ?? validConfigPaths[0];
 
 	return {
+		projectRoot: fileURLToPath(config.root),
 		contentPath,
 		configPath: configFile,
 		configExists: existingConfig !== undefined,

--- a/packages/content-utils/src/runtime/liveGit.ts
+++ b/packages/content-utils/src/runtime/liveGit.ts
@@ -1,5 +1,4 @@
 import { getEntry } from 'astro:content';
-import { join } from 'node:path';
 import { collectGitInfoForContentFiles } from './git.js';
 import type { GitTrackingInfo } from '@it-astro:content/git';
 
@@ -10,8 +9,7 @@ export async function getEntryGitInfoInner(
 ): Promise<[string, GitTrackingInfo?]> {
 	const params = args.length > 1 ? args : [args[0].collection, args[0].slug ?? args[0].id];
 	const entry = await getEntry(...params);
-
-	const file = `${entry.collection}:${entry.id}`;
+	const file = entry.filePath;
 
 	const info = trackedInfo.get(file);
 	if (!info) return [file];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded Git metadata support for content entries, allowing commit details for files managed by any content loader within the project tree.
  - Introduced a mechanism for handling asynchronous cleanup operations post-build.

- **Refactor**
  - Streamlined project path handling by consolidating logic around a single variable.
  - Enhanced post-build cleanup processes for more consistent and reliable metadata processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->