### PR TITLE
feat(astro-tests): support reading binary files from fixtures

### DIFF
--- a/.changeset/shy-deers-warn.md
+++ b/.changeset/shy-deers-warn.md
@@ -1,0 +1,11 @@
+---
+'@inox-tools/astro-tests': patch
+---
+
+Add methods to read binary files using a test fixture.
+
+The existing `readFile` and `readSrcFile` methods retain their behavior, reading files as strings,
+but now also accept an optional `encoding` parameter to change how the file is decoded into a string.
+
+Two new methods, `readFileAsBuffer` and `readSrcFileAsBuffer` mirror the existing `readFile` and `readSrcFile` methods,
+but return a `Buffer` object containing the raw bytes read from the file.


### PR DESCRIPTION
`fixture.readFile` was corrupting my images because it's currently hard-coded to read "utf8" encoded files, which is not appropriate for a PNG.

I was going to just add a second optional `options` param that would allow overriding the `readFile` options used internally, but I actually want NO options to be passed, which made it complicated. So I made a new `readRawFile` option that is a thin wrapper around `fs.promises.readFile` that changes no options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced file reading capabilities to support both binary and text files from build outputs and project sources.
	- Introduced new methods for reading files as buffers, providing greater flexibility in handling file input.
	- Updated existing methods to allow optional encoding parameters for improved file content decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->