### PR TITLE
chore: Add tests to ensure request state handles XSS scripts

### DIFF
--- a/examples/request-state/src/pages/index.astro
+++ b/examples/request-state/src/pages/index.astro
@@ -4,6 +4,10 @@ import ShowState from '../components/ShowState.astro';
 import { setState } from '@it-astro:state';
 import { $renderTimeMsg } from '../store';
 
+const xssScript = "</script><script>alert('xss')</script><script text='text/plain'>";
+
+setState('xssAttempt', xssScript);
+
 const renderTime = `Index server at ${new Date().toISOString()}`;
 
 setState('pageMessage', renderTime);


### PR DESCRIPTION
CodeRabbit identified a potential XSS, but `devalue` already handles the proper escaping to avoid it.

If we used `JSON.stringify` on the flattened `devalue` result then the code indeed be vulnerable to XSS, but since we use `devalue.stringify` it isn't. At least not in any way I could reproduce.

- Closes #180 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an additional state parameter to simulate potential security risks, enhancing overall security validations.
  
- **Tests**
	- Refined the test cleanup process to ensure each test is executed in an isolated environment.
	- Added a dedicated test to verify that simulated malicious inputs do not trigger unsafe alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->