### PR TITLE
feat(astro-tests): buildWithCli method

### DIFF
--- a/docs/src/content/docs/astro-tests.mdx
+++ b/docs/src/content/docs/astro-tests.mdx
@@ -95,6 +95,22 @@ Builds into current folder (will erase previous build).
 
 Equivalent to running [`astro build`](https://docs.astro.build/en/reference/cli-reference/#astro-build).
 
+### `buildWithCli`
+
+<p>
+  **Type:** `() => Promise<import("node:child_process").ChildProcess>`
+</p>
+
+Builds using the CLI's `astro build` command in a child process.
+
+This method runs the build in a separate process, bypassing the programmatic API. It doesn't accept configuration parameters since it uses the project's configuration files directly.
+
+While not an ideal solution for most testing scenarios, this can be useful in specific cases where the programmatic build API behaves differently from the CLI execution, particularly in CI environments.
+
+Equivalent to running `astro build` in a shell directly from your project's root.
+
+
+
 ### `preview`
 
 {(

--- a/docs/src/content/docs/astro-tests.mdx
+++ b/docs/src/content/docs/astro-tests.mdx
@@ -105,11 +105,9 @@ Builds using the CLI's `astro build` command in a child process.
 
 This method runs the build in a separate process, bypassing the programmatic API. It doesn't accept configuration parameters since it uses the project's configuration files directly.
 
-While not an ideal solution for most testing scenarios, this can be useful in specific cases where the programmatic build API behaves differently from the CLI execution, particularly in CI environments.
+While not an ideal solution for most testing scenarios, this can be useful in specific cases when testing libraries and integrations that behave differently when built using the programmatic build compared to using the CLI, which seems to be particularly more evident in CI environments.
 
-Equivalent to running `astro build` in a shell directly from your project's root.
-
-
+This method is equivalent to running `astro build` in a shell directly from your project's root.
 
 ### `preview`
 

--- a/packages/astro-tests/src/astroFixture.ts
+++ b/packages/astro-tests/src/astroFixture.ts
@@ -451,9 +451,7 @@ export async function loadFixture({ root, ...remaining }: InlineConfig): Promise
 			const nextChange = devServer ? onNextChange() : Promise.resolve();
 
 			if (newContents) {
-				await fs.promises.mkdir(path.dirname(fileURLToPath(fileUrl)), {
-					recursive: true,
-				});
+				await fs.promises.mkdir(path.dirname(fileURLToPath(fileUrl)), { recursive: true });
 				await fs.promises.writeFile(fileUrl, newContents);
 			} else {
 				await fs.promises.rm(fileUrl, { force: true });

--- a/packages/astro-tests/src/astroFixture.ts
+++ b/packages/astro-tests/src/astroFixture.ts
@@ -167,7 +167,11 @@ let nextDefaultPort = 10000 + Math.floor(Math.random() * 40000);
  *   });
  *   ```
  */
-export async function loadFixture({ root, ci = false, ...remaining }: InlineConfig): Promise<Fixture> {
+export async function loadFixture({
+	root,
+	ci = false,
+	...remaining
+}: InlineConfig): Promise<Fixture> {
 	if (!root) throw new Error("Must provide { root: './fixtures/...' }");
 	const inlineConfig: AstroInlineConfig = remaining;
 
@@ -279,24 +283,24 @@ export async function loadFixture({ root, ci = false, ...remaining }: InlineConf
 			debug(`Dev server for ${root} running at ${resolveUrl('/')}`);
 			return devServer;
 		},
-    build: async (extraInlineConfig = {}) => {
-      process.env.NODE_ENV = 'production';
-      debug(`Building fixture ${root}`);
-      
-      if (ci) {
-        const { execSync } = await import('node:child_process');
-        
+		build: async (extraInlineConfig = {}) => {
+			process.env.NODE_ENV = 'production';
+			debug(`Building fixture ${root}`);
+
+			if (ci) {
+				const { execSync } = await import('node:child_process');
+
 				debug('Using CLI build for CI environment');
 				execSync('astro build', {
 					cwd: inlineConfig.root,
 					env: { ...process.env, NODE_ENV: 'production' },
-					stdio: 'inherit'
+					stdio: 'inherit',
 				});
-      } else { 
+			} else {
 				debug('Using programmatic build');
 				return build(mergeConfig(inlineConfig, extraInlineConfig));
 			}
-    },
+		},
 		preview: async (extraInlineConfig = {}) => {
 			process.env.NODE_ENV = 'production';
 			debug(`Starting preview server for fixture ${root}`);

--- a/packages/astro-tests/src/astroFixture.ts
+++ b/packages/astro-tests/src/astroFixture.ts
@@ -291,11 +291,16 @@ export async function loadFixture({
 				const { execSync } = await import('node:child_process');
 
 				debug('Using CLI build for CI environment');
-				execSync('astro build', {
-					cwd: inlineConfig.root,
-					env: { ...process.env, NODE_ENV: 'production' },
-					stdio: 'inherit',
-				});
+				try {
+					execSync('astro build', {
+						cwd: inlineConfig.root,
+						env: { ...process.env, NODE_ENV: 'production' },
+						stdio: 'inherit',
+					});
+				} catch (error) {
+					debug('CLI build failed');
+					throw new Error(`CI build failed: ${error}`);
+				}
 			} else {
 				debug('Using programmatic build');
 				return build(mergeConfig(inlineConfig, extraInlineConfig));

--- a/packages/astro-tests/src/astroFixture.ts
+++ b/packages/astro-tests/src/astroFixture.ts
@@ -60,7 +60,7 @@ type Fixture = {
 	 *
 	 * Equivalent to running the `astro build` command in a shell.
 	 */
-	buildWithCli: () => Promise<import('node:child_process').ChildProcess>;
+	buildWithCli: () => Promise<{ stdout: string; stderr: string }>;
 	/**
 	 * Starts a preview server.
 	 *
@@ -292,7 +292,9 @@ export async function loadFixture({ root, ...remaining }: InlineConfig): Promise
 		},
 		buildWithCli: async () => {
 			const { exec } = await import('node:child_process');
-			return exec('astro build', {
+			const { promisify } = await import('node:util');
+			const execPromise = promisify(exec);
+			return execPromise('astro build', {
 				cwd: inlineConfig.root,
 				env: { ...process.env, NODE_ENV: 'production' },
 			});


### PR DESCRIPTION
@Fryuni I've added the ci config option to the `loadFixture` function. Let me know if you think this makes the most sense.

Also if there is a place we should document this property, mentioning the tradeoffs we mentioned over DM. I noticed the loadFixture function is not mentioned in the inox tools docs, happy to add it in this PR.

Side note: is there something like `pkg pr new` that we can use to easily consume this in another project? Or testing area for the test utils? I wonder if an integration test would make sense here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for executing the CLI's `astro build` command in a child process.
  - Updated documentation to include details about the new method and its usage in CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->