### PR TITLE
feat(cut-short): Implement dynamic prerender skip

### DIFF
--- a/.changeset/eager-weeks-feel.md
+++ b/.changeset/eager-weeks-feel.md
@@ -1,0 +1,7 @@
+---
+'@inox-tools/cut-short': minor
+---
+
+Implement `cancelPrerender` function, that allows a prerendered route to be skipped dynamically.
+
+When skipped, the prerendered file won't be present in the final output. Requests to those paths will be handled by the hosting platform, possibly by the server if the project has server routes.

--- a/docs/src/content/docs/cut-short.mdx
+++ b/docs/src/content/docs/cut-short.mdx
@@ -16,7 +16,7 @@ import InstallCmd from '@/components/InstallCmd.astro';
 
 ## How to use
 
-From any code that is reachable from a page rendering context can use the `endRequest` function to stop the.
+From any code that is reachable from a page rendering context can use the `endRequest` function to stop the rendering process and immediately return a web-standard `Response` for the ongoing request.
 
 A page-rendering context is when you are inside of:
 
@@ -74,6 +74,14 @@ export const GET = () => {
   </TabItem>
 </Tabs>
 
+### Pre-rendering
+
+On static sites or pre-rendered pages for hybrid sites, the `endRequest` function can be used to set the content of the pre-rendered file that will be generated. This will change the _static_ file, so the same content will be served for every request to that page.
+
+Additionally, while prerendering, you can also call the `cancelPrerender` function to skip the currently rendering page/route. In that case, the static file won't be present in the final output of your build and requests to that path will be handled by the hosting platform however it handles non-static paths (for most platforms, that will be calling the Astro server, but on fully static sites it might show a static 404 page).
+
+## Reference
+
 ### `endRequest()`
 
 **Type:** `(withResponse: Response | (() => Response | Promise<Response>)) => void`
@@ -81,6 +89,14 @@ export const GET = () => {
 Stop the current request and send back a custom response.
 
 The argument can be a `Response` object to be used directly or a function that returns a `Response` object or a promise that resolves to a `Response`.
+
+### `cancelPrerender()`
+
+**Type:** `() => void`
+
+Stop the current rendering page and mark it such that there is no rendered file on the final output.
+
+Calling this on the server will cause an internal server error.
 
 ## Options
 

--- a/packages/cut-short/src/runtime/entrypoint.ts
+++ b/packages/cut-short/src/runtime/entrypoint.ts
@@ -4,3 +4,13 @@ import { CarrierError } from '../internal/carrier.js';
 export const endRequest = (withResponse: MaybeThunk<Response>): never => {
 	throw new CarrierError(withResponse);
 };
+
+const { prerenderStopMark } = (globalThis as any)[Symbol.for('@it/cut-short')] ?? {};
+
+export const cancelPrerender = prerenderStopMark
+	? () => {
+		throw new CarrierError(new Response(prerenderStopMark));
+	}
+	: () => {
+		throw new Error('Cannot stop prerendering on server-rendered routes.');
+	};

--- a/packages/cut-short/tests/basic.test.ts
+++ b/packages/cut-short/tests/basic.test.ts
@@ -23,3 +23,7 @@ test('ending request on page frontmatter', async () => {
 	const content = await res.json();
 	expect(content).toEqual({ cutShort: true });
 });
+
+test('skipped prerenderd page should not exist', async () => {
+	expect(fixture.pathExists('block-render/index.html')).toBeFalse();
+});

--- a/packages/cut-short/tests/fixture/basic/src/pages/block-render.astro
+++ b/packages/cut-short/tests/fixture/basic/src/pages/block-render.astro
@@ -1,0 +1,7 @@
+---
+import { cancelPrerender } from '@it-astro:cut-short';
+
+export const prerender = true;
+
+cancelPrerender();
+---

--- a/packages/cut-short/virtual.d.ts
+++ b/packages/cut-short/virtual.d.ts
@@ -2,4 +2,6 @@ declare module '@it-astro:cut-short' {
 	import type { MaybeThunk } from '@inox-tools/utils/values';
 
 	export const endRequest: (withResponse: MaybeThunk<Response>) => never;
+
+	export const cancelPrerender: () => never;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to programmatically skip prerendering for specific routes, ensuring these routes are not included in the static build output.
- **Tests**
	- Introduced a test to verify that skipped prerendered pages are not present in the final build.
- **Documentation**
	- Enhanced documentation to explain the usage and effects of stopping rendering and skipping prerendering during static site generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->