### PR TITLE
Export Fixture type

### DIFF
--- a/.changeset/eight-apes-sort.md
+++ b/.changeset/eight-apes-sort.md
@@ -1,0 +1,5 @@
+---
+'@inox-tools/astro-tests': patch
+---
+
+Export fixture type for astroFixture util

--- a/packages/astro-tests/src/astroFixture.ts
+++ b/packages/astro-tests/src/astroFixture.ts
@@ -29,7 +29,7 @@ export type TestApp = {
 	toInternalApp: () => App;
 };
 
-type Fixture = {
+export type Fixture = {
 	/**
 	 * Returns the final config.
 	 * Will be automatically passed to the methods below:


### PR DESCRIPTION
Just started the process of forking the `@astrojs/web-vitals` package and had to make a kind of horrible looking type to get the `Fixture`... (for the astro built node tests)

```js
/** @typedef {Awaited<ReturnType<import('@inox-tools/astro-tests/astroFixture').loadFixture>>} Fixture */
```

This change would make it more akin to how i get the `DevServer` type:

```js
/** @typedef {import('@inox-tools/astro-tests/astroFixture').DevServer} DevServer */
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the Fixture type for the astroFixture utility publicly available in the @inox-tools/astro-tests package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->