### PR TITLE
fix(sitemap-ext): Combine sitemap integration layers to handle multi-stage adapters

### DIFF
--- a/.changeset/long-feet-build.md
+++ b/.changeset/long-feet-build.md
@@ -1,0 +1,5 @@
+---
+'@inox-tools/sitemap-ext': patch
+---
+
+Fixes sitemap being ignored when used with Vercel adapter.

--- a/packages/sitemap-ext/index.ts
+++ b/packages/sitemap-ext/index.ts
@@ -100,8 +100,6 @@ export default defineIntegration({
 			},
 		});
 
-		debugger;
-
 		return withPlugins({
 			name,
 			plugins: [routeConfigPlugin],

--- a/packages/sitemap-ext/index.ts
+++ b/packages/sitemap-ext/index.ts
@@ -109,6 +109,7 @@ export default defineIntegration({
 					const { defineRouteConfig, config } = params;
 					trailingSlash = config.trailingSlash !== 'never';
 					basePath = config.base ?? '';
+					basePath = new URL(config.base ?? '', config.site).pathname;
 					logger = params.logger;
 					baseUrl = new URL(config.base ?? '', config.site);
 


### PR DESCRIPTION
- Closes #229


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the sitemap was ignored when used with the Vercel adapter.

* **Improvements**
  * Enhanced logging for better visibility into route inclusion and configuration.
  * Improved configuration setup and filtering of sitemap entries for more accurate sitemap generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->