### PR TITLE
fix(content-utils): GitAuthor type

### DIFF
--- a/.changeset/stale-olives-push.md
+++ b/.changeset/stale-olives-push.md
@@ -1,0 +1,5 @@
+---
+'@inox-tools/content-utils': patch
+---
+
+Fixes the `GitAuthor` type

--- a/packages/content-utils/src/runtime/git.ts
+++ b/packages/content-utils/src/runtime/git.ts
@@ -31,7 +31,7 @@ function getRepoRoot(): string {
 	return result.stdout.trim();
 }
 
-type GitAuthor = {
+export type GitAuthor = {
 	name: string;
 	email: string;
 };

--- a/packages/content-utils/virtual.d.ts
+++ b/packages/content-utils/virtual.d.ts
@@ -19,6 +19,8 @@ declare module '@it-astro:content/injector' {
 }
 
 declare module '@it-astro:content/git' {
+	import type { GitAuthor } from '@inox-tools/content-utils/runtime/git';
+
 	export type EntryKey =
 		| [collection: string, idOrSlug: string]
 		| [{ collection: string; id: string }]


### PR DESCRIPTION
`GitAuthor` was not defined in the dts file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with the visibility of the GitAuthor type, making it accessible for external use.

* **Chores**
  * Updated documentation to reflect the patch addressing the GitAuthor type export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->