### PR TITLE
Fix imports in cut-short.mdx

### DIFF
--- a/docs/src/content/docs/cut-short.mdx
+++ b/docs/src/content/docs/cut-short.mdx
@@ -31,7 +31,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   <TabItem label="Common module">
 
 ```ts title="src/lib/auth.js"
-import { endRequest } from '@it-astro/cut-short';
+import { endRequest } from '@it-astro:cut-short';
 
 export function getUser() {
   if (noUser) endRequest(new Response('No user', { status: 401 }));
@@ -58,7 +58,7 @@ const user = getUser();
   <TabItem label="Endpoint">
 
 ```ts title="src/pages/userId.ts"
-import { endRequest } from '@it-astro/cut-short';
+import { endRequest } from '@it-astro:cut-short';
 import { getUser } from '../lib/auth';
 
 export const GET = () => {
@@ -135,7 +135,7 @@ This prevents components from changing the status code of the response and from 
 
 ```astro title="src/components/MyComponent.astro"
 ---
-import { endRequest } from '@it-astro/cut-short';
+import { endRequest } from '@it-astro:cut-short';
 
 // Neither of these is allowed
 endRequest(new Response('Page not found', { status: 404 }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all docs code samples to use the new import path '@it-astro:cut-short' instead of '@it-astro/cut-short' for consistency with current naming.
  * Applies across examples for auth helpers, API endpoints, and component usage.
  * No changes to runtime behavior or public APIs; docs-only update.
  * Improves copy-paste reliability for readers following the examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->