### PR TITLE
fix(sitemap-ext): keep types in sync

### DIFF
--- a/.changeset/eleven-eagles-remain.md
+++ b/.changeset/eleven-eagles-remain.md
@@ -1,0 +1,5 @@
+---
+'@inox-tools/sitemap-ext': patch
+---
+
+Fixes types to align with the official sitemap integration options


### PR DESCRIPTION
By default zod does not forward unknown keys. Instead of having to make the schema match with the one from the official integration, I made the schema only require the options you need in the integration, and do a little trickery to allow any keys but type them as the official sitemap options.

If possible, I'd like this to be merged and released this week

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected option types to align with the official sitemap integration, reducing type mismatches and improving IDE/type-checker support.

* **Refactor**
  * Streamlined options validation to focus on includeByDefault and customPages, while allowing other supported options to pass through to the underlying integration for greater flexibility.

* **Chores**
  * Added a changeset to publish a patch release reflecting these improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->