### PR TITLE
Add shallow fetch warning to content utils, git times section

### DIFF
--- a/docs/src/content/docs/content-utils/index.mdx
+++ b/docs/src/content/docs/content-utils/index.mdx
@@ -54,8 +54,7 @@ Attempting to access any entry from the collections listed during from the serve
 
 When writing a content rich site a common requirement is to show when some content was published, when it was last updated and who participated in authoring that content. Instead of tracking this manually for each entry in your content collections, this library allows you to retrieve that information from your Git history.
 
-Before using these utilities, confirm that you can fetch your repository's entire history at build time. This is an issue on hosted build services like Cloudflare's and Vercel's, which only shallow fetch (`git fetch --depth=1`), resulting in all file times resolving to the date of the tip commit. You will need to modify your service's fetching behavior, if possible, or consider moving your build pipeline to a more customizable service e.g. Vercel allows deploying via [Github Actions](https://vercel.com/kb/guide/how-can-i-use-github-actions-with-vercel). More in-depth review of this issue [here](https://fryuni.dev/notes/vercel-git/).
-
+Before using these utilities, confirm that you can fetch your repository's entire history at build time. This is an issue on hosted build services like Cloudflare's and Vercel's, which only shallow fetch (`git fetch --depth=1`), resulting in all file times resolving to the date of the tip commit. You will need to modify your service's fetching behavior, if possible, or consider moving your build pipeline to a more customizable service (e.g., Vercel allows deploying via [GitHub Actions](https://vercel.com/kb/guide/how-can-i-use-github-actions-with-vercel)). More in-depth review of this issue [here](https://fryuni.dev/notes/vercel-git/).
 #### How to use
 
 <Steps>


### PR DESCRIPTION
Resolves https://github.com/Fryuni/inox-tools/issues/249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guidance note advising builds have access to full repository history; calls out problems that can occur with shallow fetches on some hosted CI providers and suggests adjusting fetch settings or using more configurable build setups to ensure complete git history at build time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->