### PR TITLE
Add integration name tracking for collection collision detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ turbo gen                       # Scaffold new package from templates
 - `inline-mod` closure engine derived from Pulumi (Apache 2.0) — respect attribution
 - Tests are sequential by design (shared fixtures) — do not add `--parallel`
 - `custom-routing`: Cannot use inline API routes until Astro core supports virtual modules for routes
-- `content-utils/injector.ts`: Missing collision detection between integrations (3 TODOs)
+- `content-utils/injector.ts`: Reports integration names in collision errors; inter-integration collisions detected at virtual module import time
 
 ## CI
 

--- a/packages/content-utils/src/integration/index.ts
+++ b/packages/content-utils/src/integration/index.ts
@@ -19,6 +19,15 @@ export type InjectCollectionOptions = {
 	entrypoint: string;
 
 	/**
+	 * Name of the integration injecting this collection.
+	 * Used for improved error reporting on collection conflicts.
+	 *
+	 * When using the `injectCollections` utility, this is automatically populated
+	 * from the integration's logger label if not explicitly provided.
+	 */
+	integrationName?: string;
+
+	/**
 	 * Seed collections using this template if they are not present.
 	 *
 	 * @see {seedCollections}
@@ -51,7 +60,10 @@ export const integration = withApi(
 					['astro:config:setup', 'astro:config:done', 'astro:build:start', 'astro:server:setup'],
 					(options: InjectCollectionOptions) => {
 						debug('Injecting collection:', options);
-						state.injectedCollectionsEntrypoints.push(options.entrypoint);
+						state.injectedCollectionsEntrypoints.push({
+						entrypoint: options.entrypoint,
+						integrationName: options.integrationName,
+					});
 
 						if (options.seedTemplateDirectory) {
 							api.seedCollections({

--- a/packages/content-utils/src/integration/injectorPlugin.ts
+++ b/packages/content-utils/src/integration/injectorPlugin.ts
@@ -40,17 +40,52 @@ export const injectorPlugin = (state: IntegrationState): Plugin => {
 		},
 		load(id) {
 			switch (id) {
-				case RESOLVED_INJECTOR_VIRTUAL_MODULE:
-					debug('Generating injected collection modole from:', entrypoints);
-					return [
-						...entrypoints.map(
-							(entrypoint, index) =>
-								`import {collections as __collections${index}} from '${entrypoint}';`
-						),
-						'export const injectedCollections = {',
-						...entrypoints.map((_, index) => `...__collections${index},`),
-						'};',
-					].join('\n');
+				case RESOLVED_INJECTOR_VIRTUAL_MODULE: {
+					debug('Generating injected collection module from:', entrypoints);
+
+					const lines: string[] = [];
+
+					// Import each entrypoint's collections
+					for (let i = 0; i < entrypoints.length; i++) {
+						lines.push(
+							`import {collections as __collections${i}} from '${entrypoints[i].entrypoint}';`
+						);
+					}
+
+					lines.push('');
+					lines.push('export const collectionSources = {};');
+					lines.push('export const injectedCollections = {};');
+
+					// Generate per-entrypoint merge with collision detection
+					for (let i = 0; i < entrypoints.length; i++) {
+						const nameExpr = entrypoints[i].integrationName
+							? JSON.stringify(entrypoints[i].integrationName)
+							: 'undefined';
+
+						lines.push('');
+						lines.push(
+							`for (const [__key, __value] of Object.entries(__collections${i})) {`
+						);
+						lines.push('  if (__key in injectedCollections) {');
+						lines.push('    const __prevOwner = collectionSources[__key];');
+						lines.push(`    const __curOwner = ${nameExpr};`);
+						lines.push(
+							'    if (__prevOwner !== undefined && __curOwner !== undefined && __prevOwner !== __curOwner) {'
+						);
+						lines.push(
+							'      throw new Error(`Content collection "${__key}" is injected by both "${__prevOwner}" and "${__curOwner}". Only one integration may inject a given collection key.`);'
+						);
+						lines.push('    }');
+						lines.push('  }');
+						lines.push('  injectedCollections[__key] = __value;');
+						lines.push(
+							`  if (${nameExpr} !== undefined) collectionSources[__key] = ${nameExpr};`
+						);
+						lines.push('}');
+					}
+
+					return lines.join('\n');
+				}
 				case RESOLVED_CONTENT_VIRTUAL_MODULE:
 					debug('Generating fancy content module');
 					return [

--- a/packages/content-utils/src/integration/state.ts
+++ b/packages/content-utils/src/integration/state.ts
@@ -1,9 +1,14 @@
 import type { AstroIntegrationLogger } from 'astro';
 import type { ResolvedContentPaths } from '../internal/resolver.js';
 
+export interface InjectedCollectionEntry {
+	entrypoint: string;
+	integrationName?: string;
+}
+
 export interface IntegrationState {
 	logger: AstroIntegrationLogger;
-	injectedCollectionsEntrypoints: string[];
+	injectedCollectionsEntrypoints: InjectedCollectionEntry[];
 	staticOnlyCollections: string[];
 	contentPaths: ResolvedContentPaths;
 	contentDataEntrypoint?: string;

--- a/packages/content-utils/src/integration/utilities.ts
+++ b/packages/content-utils/src/integration/utilities.ts
@@ -14,7 +14,10 @@ export const injectCollections = defineUtility('astro:config:setup')((
 ) => {
 	const api = integration.fromSetup(params);
 
-	return api.injectCollection(options);
+	return api.injectCollection({
+		...options,
+		integrationName: options.integrationName ?? params.logger.label,
+	});
 });
 
 export const seedCollections = defineUtility('astro:config:setup')((

--- a/packages/content-utils/src/runtime/injector.ts
+++ b/packages/content-utils/src/runtime/injector.ts
@@ -1,6 +1,11 @@
-import { injectedCollections, type CollectionConfig } from '@it-astro:content/injector';
+import { injectedCollections, collectionSources, type CollectionConfig } from '@it-astro:content/injector';
 import { isFancyCollection, tryGetOriginalFancyCollection } from './fancyContent.js';
 import { AstroError } from 'astro/errors';
+
+function getOwnerLabel(key: string): string {
+	const owner = collectionSources[key];
+	return owner ? `the "${owner}" integration` : 'an integration';
+}
 
 /**
  * Extend the given collection map with collections defined by integrations.
@@ -18,18 +23,14 @@ export function injectCollections(
 
 		if (originFancyCollection === null) {
 			throw new AstroError(
-				// TODO: Report which integration added the collection.
-				`Content collection "${key}" overrides a collection injected by an integration.`,
+				`Content collection "${key}" overrides a collection injected by ${getOwnerLabel(key)}.`,
 				'Try to use a different collection name.'
 			);
 		}
 
-		// TODO: Detect when two different integrations collide
-
 		if (!Object.is(originFancyCollection, injectedCollection)) {
 			throw new AstroError(
-				// TODO: Report which integration added the collection.
-				`Content collection "${key}" extends from one an injected collection, but overrides a different collection.`,
+				`Content collection "${key}" extends from an injected collection, but overrides a different collection than the one injected by ${getOwnerLabel(key)}.`,
 				'When extending an injected collection you must not change the collection name.'
 			);
 		}

--- a/packages/content-utils/tests/injector-runtime.test.ts
+++ b/packages/content-utils/tests/injector-runtime.test.ts
@@ -3,9 +3,11 @@ import { z } from 'astro/zod';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const injectedCollections = vi.hoisted(() => ({} as Record<string, any>));
+const collectionSources = vi.hoisted(() => ({} as Record<string, string>));
 
 vi.mock('@it-astro:content/injector', () => ({
 	injectedCollections,
+	collectionSources,
 }));
 
 vi.mock('astro:content', async () => {
@@ -27,6 +29,9 @@ import { injectCollections } from '../src/runtime/injector.js';
 afterEach(() => {
 	for (const key of Object.keys(injectedCollections)) {
 		delete injectedCollections[key];
+	}
+	for (const key of Object.keys(collectionSources)) {
+		delete collectionSources[key];
 	}
 });
 
@@ -88,6 +93,35 @@ describe('injectCollections', () => {
 		).toThrow(AstroError);
 	});
 
+	it('reports integration name when a project overrides an injected collection', () => {
+		const fancy = makeFancy();
+		injectedCollections.blog = fancy;
+		collectionSources.blog = 'my-blog-plugin';
+
+		expect(() =>
+			injectCollections({
+				blog: {
+					type: 'content',
+					schema: z.object({}),
+				},
+			})
+		).toThrow(/my-blog-plugin/);
+	});
+
+	it('uses generic message when integration name is not provided', () => {
+		const fancy = makeFancy();
+		injectedCollections.blog = fancy;
+
+		expect(() =>
+			injectCollections({
+				blog: {
+					type: 'content',
+					schema: z.object({}),
+				},
+			})
+		).toThrow(/an integration/);
+	});
+
 	it('throws when extending the wrong injected collection', () => {
 		const injected = makeFancy();
 		const otherFancy = makeFancy();
@@ -98,5 +132,18 @@ describe('injectCollections', () => {
 				blog: otherFancy(),
 			})
 		).toThrow(AstroError);
+	});
+
+	it('reports integration name when extending the wrong injected collection', () => {
+		const injected = makeFancy();
+		const otherFancy = makeFancy();
+		injectedCollections.blog = injected;
+		collectionSources.blog = 'blog-integration';
+
+		expect(() =>
+			injectCollections({
+				blog: otherFancy(),
+			})
+		).toThrow(/blog-integration/);
 	});
 });

--- a/packages/content-utils/virtual.d.ts
+++ b/packages/content-utils/virtual.d.ts
@@ -16,6 +16,7 @@ declare module '@it-astro:content/injector' {
 
 	export type CollectionConfig = ReturnType<typeof defineCollection>;
 	export const injectedCollections: Record<string, CollectionConfig | FancyCollection>;
+	export const collectionSources: Record<string, string>;
 }
 
 declare module '@it-astro:content/git' {


### PR DESCRIPTION
## Summary
This PR enhances collection injection error reporting by tracking which integration injected each collection, enabling more informative error messages when collections collide or are overridden.

## Key Changes

- **Virtual module generation**: Refactored the injector plugin to generate runtime code that tracks collection sources alongside the collections themselves. The generated code now:
  - Imports collections from each entrypoint
  - Maintains a `collectionSources` map to record which integration owns each collection
  - Detects inter-integration collisions at import time and throws descriptive errors

- **Runtime error reporting**: Updated `injectCollections()` to use the tracked integration names in error messages:
  - Reports the specific integration name when a project collection overrides an injected one
  - Reports the specific integration name when extending the wrong injected collection
  - Falls back to generic "an integration" message when integration name is unavailable

- **Type system updates**:
  - Added `InjectedCollectionEntry` interface to track both entrypoint and integration name
  - Added `integrationName` optional field to `InjectCollectionOptions`
  - Exported `collectionSources` from the virtual injector module

- **Utility enhancement**: The `injectCollections()` utility now automatically populates `integrationName` from the integration's logger label if not explicitly provided

- **Test coverage**: Added tests verifying:
  - Integration names appear in collision error messages
  - Generic fallback message when integration name is unavailable
  - Integration names reported when extending wrong collections

## Implementation Details

The collision detection happens at two levels:
1. **Virtual module import time**: Inter-integration collisions are caught when the generated module is imported, preventing conflicting integrations from both injecting the same collection
2. **Runtime**: Project-level overrides are caught when `injectCollections()` is called, with proper attribution to the original integration

This approach ensures early detection of conflicts while maintaining clear error messages that help developers identify the source of the problem.

https://claude.ai/code/session_016xmmzrXmsoxx2d1EJuVAhK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* Content collection injection error messages now clearly identify which integration is causing conflicts or validation issues, improving the debugging experience.
* Collision detection for injected collections has been enhanced to explicitly report the integration responsible for conflicts in error messages.
* Better integration attribution in error reporting helps developers quickly resolve content collection injection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->