### PR TITLE
Drop Astro 6 and Vite 7 support

### DIFF
--- a/.changeset/great-otters-upgrade.md
+++ b/.changeset/great-otters-upgrade.md
@@ -1,0 +1,23 @@
+---
+'@inox-tools/astro-tests': major
+'@inox-tools/astro-when': major
+'@inox-tools/custom-routing': major
+'@inox-tools/cut-short': major
+'@inox-tools/inline-mod': major
+'@inox-tools/portal-gun': major
+'@inox-tools/request-nanostores': major
+'@inox-tools/request-state': major
+'@inox-tools/runtime-logger': major
+'@inox-tools/star-warp': major
+'@inox-tools/content-utils': minor
+'@inox-tools/modular-station': minor
+'@inox-tools/route-config': minor
+'@inox-tools/server-islands': minor
+'@inox-tools/sitemap-ext': minor
+---
+
+Require Astro 7 and Vite 8, dropping support for Astro 6 and Vite 7.
+
+All Inox Tools integrations now require Astro `^7` in their peer dependencies. Integrations that peer-depend on Vite now require Vite `^8`, matching the Vite version bundled by Astro 7. Additionally, `@inox-tools/star-warp` now requires Starlight `^0.41`.
+
+To migrate, upgrade your project to Astro 7 (see the [Astro 7 upgrade guide](https://docs.astro.build/en/guides/upgrade-to/v7/)), which brings Vite 8 along. Starlight users must upgrade to `@astrojs/starlight` `^0.41`. No API changes were made to the integrations themselves; projects already on Astro 7 and Vite 8 can upgrade without code changes.

--- a/docs/src/content/docs/content-utils/integration.mdx
+++ b/docs/src/content/docs/content-utils/integration.mdx
@@ -67,7 +67,7 @@ export default function yourIntegration(): AstroIntegration {
 
 ### `@it-astro:content` virtual module
 
-This virtual module provides the same content collection API as `astro:content`, with the exception of `defineCollection`. Instead, `defineCollection` creates a `FancyCollection`, that can be extended by users of your integration. It also re-exports `z` from `astro/zod` for Astro 7 compatibility.
+This virtual module provides the same content collection API as `astro:content`, with the exception of `defineCollection`. Instead, `defineCollection` creates a `FancyCollection`, that can be extended by users of your integration. It also re-exports `z` from `astro/zod`.
 
 For integration authors, it is a drop-in replacement.
 

--- a/packages/astro-tests/src/testAdapter.ts
+++ b/packages/astro-tests/src/testAdapter.ts
@@ -82,10 +82,8 @@ export default function (options: Options = {}): AstroIntegration {
 									const url = new URL(request.url);
 									if(this.#manifest.assets.has(url.pathname)) {
 										const assetPath = this.removeBase(url.pathname);
-										const clientRoots = ['../client/', '../../client/'];
-										const assetPaths = [assetPath, assetPath + '.html', assetPath + '/index.html'];
-										const filePaths = clientRoots.flatMap((clientRoot) =>
-											assetPaths.map((assetPath) => new URL(clientRoot + assetPath, import.meta.url))
+										const filePaths = [assetPath, assetPath + '.html', assetPath + '/index.html'].map(
+											(assetPath) => new URL('../client/' + assetPath, import.meta.url)
 										);
 										const filePath = filePaths.find(
 											(filePath) => fs.existsSync(filePath) && fs.statSync(filePath).isFile()

--- a/packages/astro-when/src/index.ts
+++ b/packages/astro-when/src/index.ts
@@ -68,14 +68,11 @@ export default function astroWhen(): AstroIntegration {
 				});
 			},
 			'astro:config:done': (params) => {
-				// Check if the version of Astro being used has the `injectTypes` utility.
-				if (typeof params.injectTypes === 'function') {
-					debug('Injecting types in .astro structure');
-					params.injectTypes({
-						filename: 'types.d.ts',
-						content: "import '@inox-tools/astro-when';",
-					});
-				}
+				debug('Injecting types in .astro structure');
+				params.injectTypes({
+					filename: 'types.d.ts',
+					content: "import '@inox-tools/astro-when';",
+				});
 			},
 			'astro:build:done': () => {
 				delete (globalThis as any)[key];

--- a/packages/astro-when/tests/hybrid-output.test.ts
+++ b/packages/astro-when/tests/hybrid-output.test.ts
@@ -1,4 +1,3 @@
-import { rename } from 'node:fs/promises';
 import { loadFixture, type DevServer, type TestApp } from '@inox-tools/astro-tests/astroFixture';
 import testAdapter from '@inox-tools/astro-tests/testAdapter';
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
@@ -84,21 +83,6 @@ describe('Astro when on a static output project with an adapter (old hybrid mode
 			const content = await res.text();
 
 			expect(content).toEqual('prerender');
-		});
-
-		test('finds directory-index prerendered pages from the Astro 6 client root', async () => {
-			const clientRoot = new URL('./client/', fixture.config.outDir);
-			const legacyClientRoot = new URL('../client/', fixture.config.outDir);
-			await rename(clientRoot, legacyClientRoot);
-
-			try {
-				app.toInternalApp().manifest.assets.add('/directory');
-				const res = await app.render(new Request('http://example.com/directory'));
-
-				expect(await res.text()).toContain('prerender');
-			} finally {
-				await rename(legacyClientRoot, clientRoot);
-			}
 		});
 	});
 });

--- a/packages/custom-routing/package.json
+++ b/packages/custom-routing/package.json
@@ -38,6 +38,6 @@
     "vite": "catalog:"
   },
   "peerDependencies": {
-    "astro": ">=3"
+    "astro": "catalog:lax"
   }
 }

--- a/packages/cut-short/src/index.ts
+++ b/packages/cut-short/src/index.ts
@@ -66,14 +66,11 @@ export default function cutShort({
 				});
 			},
 			'astro:config:done': (params) => {
-				// Check if the version of Astro being used has the `injectTypes` utility.
-				if (typeof params.injectTypes === 'function') {
-					debug('Injecting types in .astro structure');
-					params.injectTypes({
-						filename: 'types.d.ts',
-						content: "import '@inox-tools/cut-short';",
-					});
-				}
+				debug('Injecting types in .astro structure');
+				params.injectTypes({
+					filename: 'types.d.ts',
+					content: "import '@inox-tools/cut-short';",
+				});
 			},
 			'astro:build:done': async ({ assets, logger }) => {
 				const pairs = Array.from(assets.entries());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,7 @@ catalogs:
       version: 4.4.3
   lax:
     '@astrojs/starlight':
-      specifier: ^0.38.0 || ^0.39.0 || ^0.40.0 || ^0.41.0
+      specifier: ^0.41.0
       version: 0.41.3
 
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -98,11 +98,11 @@ catalogMode: manual
 
 catalogs:
   lax:
-    '@astrojs/starlight': ^0.38.0 || ^0.39.0 || ^0.40.0 || ^0.41.0
-    astro: ^6 || ^7
+    '@astrojs/starlight': ^0.41.0
+    astro: ^7
   min:
-    astro: ^6 || ^7
-    vite: ^7 || ^8
+    astro: ^7
+    vite: ^8
 
 onlyBuiltDependencies:
   - core-js-pure


### PR DESCRIPTION
## Summary

- require Astro 7 and Vite 8 across published package compatibility ranges
- require Starlight 0.41 for `@inox-tools/star-warp`
- remove the Astro 6 adapter output fallback and obsolete Astro version guards
- add breaking release changesets for all 15 affected packages

## Verification

- `pnpm build` — 17/17 packages passed
- `pnpm test` — 34/34 Turbo tasks passed
- `pnpm exec prettier --check ...` — all changed files passed
- `pnpm exec changeset status` — 10 major and 5 minor releases validated
- packed manifests confirmed Astro `^7`, Vite `^8`, and Starlight `^0.41.0`