### PR TITLE
docs: sync package descriptions

### DIFF
--- a/docs/src/content/docs/astro-tests.mdx
+++ b/docs/src/content/docs/astro-tests.mdx
@@ -1,7 +1,7 @@
 ---
 title: Astro Test Utils
 packageName: '@inox-tools/astro-tests'
-description: Utilities for testing your own Astro integrations and libraries based on Astro's own testing tools.
+description: Utilities for testing your own Astro integrations and libraries based on Astro's own testing tools
 ---
 
 Astro's current ecosystem lacks solutions for testing integrations, adapters, and components without either copying internal entire parts of the Astro code or bypassing package encapsulation to import internal modules from Astro. This tool aims to fill that gap by providing high-level wrapper over the known practices required to test Astro libraries.

--- a/docs/src/content/docs/astro-when.mdx
+++ b/docs/src/content/docs/astro-when.mdx
@@ -1,7 +1,7 @@
 ---
 title: Astro When
 packageName: '@inox-tools/astro-when'
-description: Know when and where your code is running in your Astro project
+description: Integration that informs when in Astro's lifecycle the code is running
 ---
 
 This integration provides an import that exposes when in the lifecycle of an Astro codebase your code is running.

--- a/docs/src/content/docs/content-utils/index.mdx
+++ b/docs/src/content/docs/content-utils/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Content Utils
 packageName: '@inox-tools/content-utils'
-description: Get creation and update time for your content from your git history.
+description: Utilities to work with content collections on an Astro project from an integration or library.
 howItWorks: /how-it-works/content-utils
 sidebar:
   label: For projects

--- a/docs/src/content/docs/custom-routing.mdx
+++ b/docs/src/content/docs/custom-routing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Custom Astro Routing
 packageName: '@inox-tools/custom-routing'
-description: Define custom routes and entrypoints in an Astro project without relying on the file-based routing.
+description: Define custom routing instead of Astro's default file-based routing.
 sidebar:
   label: Overview
   order: 0

--- a/docs/src/content/docs/cut-short.mdx
+++ b/docs/src/content/docs/cut-short.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cut-Short Requests
 packageName: '@inox-tools/cut-short'
-description: Interrupt rendering a request and send a custom response while keeping your code organized.
+description: Immediately halt request processing and return custom responses effortlessly.
 ---
 
 Cut-short is an Astro integration that lets you stop processing a request instantly and send back a custom response, simplifying control flow in your Astro applications. By introducing the `endRequest` function, it eliminates the need for cumbersome workarounds like bubbling up response objects, throwing and catching sentinel errors, implementing custom middleware logic or replicating error response logic across all your pages.

--- a/docs/src/content/docs/inline-mod/index.md
+++ b/docs/src/content/docs/inline-mod/index.md
@@ -1,7 +1,7 @@
 ---
 title: Inline Virtual Modules
 packageName: '@inox-tools/inline-mod'
-description: Pass inline JS values and functions as a virtual module to Vite projects.
+description: Define a virtual module inline with any reference to buildtime values
 sidebar:
   label: Overview
   order: 0

--- a/docs/src/content/docs/request-state.mdx
+++ b/docs/src/content/docs/request-state.mdx
@@ -1,6 +1,6 @@
 ---
 title: Request State
-description: Request State
+description: Shared request state between server and client
 packageName: '@inox-tools/request-state'
 challenger: [Florian, Oliver]
 ---

--- a/docs/src/content/docs/runtime-logger.mdx
+++ b/docs/src/content/docs/runtime-logger.mdx
@@ -1,7 +1,7 @@
 ---
 title: Runtime Logger
 packageName: '@inox-tools/runtime-logger'
-description: Access an Astro Integration Logger from the runtime of a project.
+description: Expose Astro Integration Logger at runtime for consistent output
 howItWorks: /how-it-works/runtime-logger
 ---
 

--- a/docs/src/content/docs/server-islands.mdx
+++ b/docs/src/content/docs/server-islands.mdx
@@ -1,7 +1,7 @@
 ---
 title: Server Islands Utilities
 packageName: '@inox-tools/server-islands'
-description: Utilities for working with server-islands.
+description: Common tools and utilities for working with Server Islands.
 ---
 
 This integration provides a set of utilities to work with Astro's [Server Islands](https://docs.astro.build/en/guides/server-islands/).

--- a/docs/src/content/docs/sitemap-ext.mdx
+++ b/docs/src/content/docs/sitemap-ext.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sitemap Extensions
-description: An unofficial extension of the official @astrojs/sitemap integration.
+description: Higher level extension over Astro's official sitemap integration
 packageName: '@inox-tools/sitemap-ext'
 ---
 


### PR DESCRIPTION
## Summary
- synchronize canonical documentation page descriptions with package manifest descriptions
- update all ten existing package docs pages that had drifted

Closes #168

## Verification
- `pnpm build`
- `pnpm --dir docs build`
- `pnpm exec prettier --check` on all changed docs files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and clarified descriptions across several integration and utility documentation pages.
  * Updated wording for routing, request state, runtime logging, server islands, content utilities, sitemap extensions, and other features.
  * Standardized descriptions to more accurately communicate functionality and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->