### PR TITLE
feat(git-redirect): generate redirects from Git rename history

### DIFF
--- a/.changeset/fresh-files-redirect.md
+++ b/.changeset/fresh-files-redirect.md
@@ -1,0 +1,5 @@
+---
+'@inox-tools/git-redirect': minor
+---
+
+Add an Astro integration that creates redirects from Git file rename history.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,6 +43,9 @@ pkg/request-state:
 pkg/route-config:
 - 'packages/route-config/**'
 
+pkg/git-redirect:
+- 'packages/git-redirect/**'
+
 pkg/content-utils:
 - 'packages/content-utils/**'
 

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -56,6 +56,10 @@ export default defineConfig({
 							link: '/custom-routing',
 						},
 						{
+							label: 'Git Redirect',
+							link: '/git-redirect',
+						},
+						{
 							label: 'Sitemap Extensions',
 							link: '/sitemap-ext',
 						},

--- a/docs/src/content/docs/git-redirect.mdx
+++ b/docs/src/content/docs/git-redirect.mdx
@@ -1,0 +1,70 @@
+---
+title: Git Redirect
+description: Generate Astro redirects from Git rename history.
+packageName: '@inox-tools/git-redirect'
+---
+
+`@inox-tools/git-redirect` creates redirects for routes whose `.astro`, `.md`, or `.mdx` files were renamed in Git. It follows chained renames so an older URL redirects to the page's current route.
+
+## Installation
+
+import InstallCmd from '@/components/InstallCmd.astro';
+
+<InstallCmd />
+
+## Configuration
+
+Add `gitRedirect()` to your Astro configuration. Its sources are processed in order:
+
+```ts title="astro.config.mjs"
+import { defineConfig } from 'astro/config';
+import gitRedirect from '@inox-tools/git-redirect';
+
+export default defineConfig({
+	integrations: [
+		gitRedirect([
+			{
+				path: 'src/pages',
+				prefix: '/',
+			},
+		]),
+	],
+});
+```
+
+### Sources
+
+Each source has these fields:
+
+- `path`: an existing page file or directory. Relative paths resolve from the Astro project root; absolute paths are also supported. A file generates redirects only for that page, while a directory is searched recursively for supported page files.
+- `prefix`: the URL prefix for the source's routes. It is normalized to have a leading slash and no trailing slash, except for `/`.
+
+For example, a source at `src/pages/guides` with a `/docs` prefix maps `src/pages/guides/getting-started.mdx` to `/docs/getting-started`.
+
+## Route and redirect behavior
+
+Routes are derived from the source path: their file extension is removed, and a terminal `index` segment is collapsed. For example, `src/pages/docs/index.astro` becomes `/docs` with the root prefix, and `src/pages/blog/[slug].mdx` becomes `/blog/[slug]`.
+
+The integration examines the complete first-parent Git history from `HEAD` and creates redirects from historical paths to the current paths. A redirect is generated only when its current target still exists as a file.
+
+Existing Astro routes and redirects configured in `astro.config` take precedence over generated redirects. If more than one source would generate the same redirect, the earlier source wins.
+
+### Dynamic routes
+
+A dynamic redirect is generated only when the old and current routes have identical parameter bindings, including parameter names, positions, and rest parameters. For example, a rename from `blog/[slug].astro` to `posts/[slug].astro` can redirect, while renaming it to `posts/[id].astro` cannot.
+
+### Nested repositories
+
+When a directory source contains a nested Git repository, that nested repository is ignored while scanning the directory. To generate redirects for it, configure it as a separate source.
+
+## Git history in CI
+
+Every source must be inside a Git repository with complete, non-shallow history available during the build. The integration rejects shallow repositories because a partial history could omit old routes.
+
+For GitHub Actions, configure `actions/checkout` to fetch the full history:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+```

--- a/docs/src/content/docs/git-redirect.mdx
+++ b/docs/src/content/docs/git-redirect.mdx
@@ -4,7 +4,7 @@ description: Generate Astro redirects from Git rename history.
 packageName: '@inox-tools/git-redirect'
 ---
 
-`@inox-tools/git-redirect` creates redirects for routes whose `.astro`, `.md`, or `.mdx` files were renamed in Git. It follows chained renames so an older URL redirects to the page's current route.
+`@inox-tools/git-redirect` creates redirects for routes whose `.astro`, `.md`, `.mdx`, `.html`, `.markdown`, `.mdown`, `.mkdn`, `.mkd`, `.mdwn`, `.js`, or `.ts` files were renamed in Git. Ordinary rename chains collapse to the page's current route, while separate lifetimes of a reused path remain isolated rather than being joined into one chain.
 
 ## Installation
 
@@ -36,7 +36,7 @@ export default defineConfig({
 
 Each source has these fields:
 
-- `path`: an existing page file or directory. Relative paths resolve from the Astro project root; absolute paths are also supported. A file generates redirects only for that page, while a directory is searched recursively for supported page files.
+- `path`: an existing page file or directory. Relative paths resolve from the Astro project root; absolute paths are also supported. A file generates redirects only for that page, while a directory is searched recursively for supported page files. For sources in Astro's pages directory, path components beginning with `_` or `.` are excluded, except for `.well-known`.
 - `prefix`: the URL prefix for the source's routes. It is normalized to have a leading slash and no trailing slash, except for `/`.
 
 For example, a source at `src/pages/guides` with a `/docs` prefix maps `src/pages/guides/getting-started.mdx` to `/docs/getting-started`.

--- a/packages/git-redirect/README.md
+++ b/packages/git-redirect/README.md
@@ -1,0 +1,59 @@
+<p align="center">
+    <img alt="InoxTools" width="350px" src="https://github.com/Fryuni/inox-tools/blob/main/assets/shield.png?raw=true"/>
+</p>
+
+# Astro Git Redirect
+
+Create Astro redirects from the Git rename history of your pages.
+
+## Install
+
+```sh
+npm i @inox-tools/git-redirect
+```
+
+Add the integration to your `astro.config.mjs`:
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro';
+import gitRedirect from '@inox-tools/git-redirect';
+
+export default defineConfig({
+  integrations: [
+    gitRedirect([
+      { path: 'src/pages', prefix: '/' },
+      { path: 'content/guides', prefix: '/guides' },
+    ]),
+  ],
+});
+```
+
+## Sources
+
+`gitRedirect()` accepts an ordered array of sources. Each source has a `path` and a `prefix`:
+
+- `path` must be an existing file or directory. Relative paths resolve from the Astro project root; absolute paths are also supported. The path must be inside a Git repository.
+- `prefix` is the URL base for the source. It is normalized to a leading slash with trailing slashes removed, except for `/`.
+
+A directory source recursively considers supported pages within that directory. A file source only considers that current file and its rename history; its routes are relative to the file's parent directory. Redirects are generated only for `.astro`, `.md`, and `.mdx` files whose current target still exists.
+
+For both old and current paths, the extension is removed and a terminal `index` segment is collapsed. For example, with `{ path: 'content/guides', prefix: '/guides' }`, renaming `content/guides/old/index.md` to `content/guides/getting-started.mdx` creates `/guides/old` → `/guides/getting-started`.
+
+All names in a rename chain redirect to the current page.
+
+## Redirect precedence
+
+The integration never replaces an existing route or an explicit Astro redirect. If generated redirects collide, sources are processed in configuration order and the earlier source wins.
+
+Dynamic routes are redirected only when their parameter bindings are identical and in the same order. For example, `[id]/old.md` can redirect to `[id]/current.md`, but `[id].md` does not redirect to `[slug].md`, and `[...parts].md` does not redirect to `[parts].md`.
+
+Nested Git repositories are ignored when walking a directory source. Configure a nested repository as its own source to generate its redirects.
+
+## Git history
+
+For every configured source, the integration finds its containing repository and inspects the first-parent rename history at `HEAD`, once per repository. Complete Git history is required: shallow repositories fail the build. In GitHub Actions, configure checkout with `fetch-depth: 0`.
+
+### License
+
+Astro Git Redirect is available under the MIT license.

--- a/packages/git-redirect/README.md
+++ b/packages/git-redirect/README.md
@@ -36,11 +36,11 @@ export default defineConfig({
 - `path` must be an existing file or directory. Relative paths resolve from the Astro project root; absolute paths are also supported. The path must be inside a Git repository.
 - `prefix` is the URL base for the source. It is normalized to a leading slash with trailing slashes removed, except for `/`.
 
-A directory source recursively considers supported pages within that directory. A file source only considers that current file and its rename history; its routes are relative to the file's parent directory. Redirects are generated only for `.astro`, `.md`, and `.mdx` files whose current target still exists.
+A directory source recursively considers supported pages within that directory. A file source only considers that current file and its rename history; its routes are relative to the file's parent directory. Supported page files have one of these extensions: `.astro`, `.md`, `.mdx`, `.html`, `.markdown`, `.mdown`, `.mkdn`, `.mkd`, `.mdwn`, `.js`, or `.ts`. Within Astro's pages directory, path components that begin with `_` or `.` are excluded, except for `.well-known`. Redirects are generated only when the current target still exists.
 
 For both old and current paths, the extension is removed and a terminal `index` segment is collapsed. For example, with `{ path: 'content/guides', prefix: '/guides' }`, renaming `content/guides/old/index.md` to `content/guides/getting-started.mdx` creates `/guides/old` → `/guides/getting-started`.
 
-All names in a rename chain redirect to the current page.
+All names in an ordinary rename chain redirect to the current page. If a path is reused later, its separate lifetimes are kept isolated rather than connected into one chain.
 
 ## Redirect precedence
 

--- a/packages/git-redirect/README.md
+++ b/packages/git-redirect/README.md
@@ -16,7 +16,7 @@ Add the integration to your `astro.config.mjs`:
 
 ```js
 // astro.config.mjs
-import { defineConfig } from 'astro';
+import { defineConfig } from 'astro/config';
 import gitRedirect from '@inox-tools/git-redirect';
 
 export default defineConfig({

--- a/packages/git-redirect/package.json
+++ b/packages/git-redirect/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@inox-tools/git-redirect",
+  "version": "0.0.0",
+  "description": "Astro integration that creates redirects from Git file renames.",
+  "keywords": [
+    "astro-integration",
+    "withastro",
+    "astro",
+    "redirects",
+    "git"
+  ],
+  "repository": {
+    "url": "https://github.com/Fryuni/inox-tools"
+  },
+  "license": "MIT",
+  "author": "Luiz Ferraz <luiz@lferraz.com>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "prepublish": "pnpm run build",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "astro": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "astro": "catalog:lax"
+  }
+}

--- a/packages/git-redirect/src/index.ts
+++ b/packages/git-redirect/src/index.ts
@@ -26,7 +26,10 @@ export interface GitRedirectSource {
 	/**
 	 * An existing file or directory, resolved relative to the Astro project root (unless absolute).
 	 *
-	 * A file generates redirects for that page; a directory generates redirects for supported pages within it.
+	 * A file generates redirects for that page; a directory generates redirects for supported pages within it. A
+	 * supported page file has a `.astro`, `.html`, `.md`, `.mdx`, `.markdown`, `.mdown`, `.mkdn`, `.mkd`, `.mdwn`,
+	 * `.js`, or `.ts` extension. Within Astro's pages directory, its path cannot contain a component beginning with
+	 * `_` or `.`, except for `.well-known`.
 	 */
 	path: string;
 	/**

--- a/packages/git-redirect/src/index.ts
+++ b/packages/git-redirect/src/index.ts
@@ -1,0 +1,303 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { stat, readdir } from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AstroIntegration } from 'astro';
+
+const supportedExtensions: Record<string, true> = {
+	'.astro': true,
+	'.md': true,
+	'.mdx': true,
+};
+
+export interface GitRedirectSource {
+	path: string;
+	prefix: string;
+}
+
+type ResolvedSource = {
+	path: string;
+	prefix: string;
+	routeRoot: string;
+	repository: string;
+	file: boolean;
+};
+
+type Rename = {
+	from: string;
+	to: string;
+};
+
+export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegration {
+	return {
+		name: '@inox-tools/git-redirect',
+		hooks: {
+			'astro:config:setup': async ({ config, updateConfig }) => {
+				const root = fileURLToPath(config.root);
+				const resolvedSources = await Promise.all(
+					sources.map((source) => resolveSource(root, source))
+				);
+				const renamesByRepository = await getRepositoryRenames(resolvedSources);
+				const existingRedirects = config.redirects ?? {};
+				const generatedRedirects: Record<string, string> = {};
+				const currentRoutes = new Set<string>();
+				for (const routes of await Promise.all(resolvedSources.map(getCurrentRoutes))) {
+					for (const route of routes) currentRoutes.add(route);
+				}
+
+				for (const source of resolvedSources) {
+					const renames = renamesByRepository.get(source.repository);
+					if (!renames) continue;
+
+					for (const [from, to] of renames) {
+						if (!hasSupportedExtension(from) || !hasSupportedExtension(to)) continue;
+
+						const previousPath = resolveRepositoryPath(source.repository, from);
+						const currentPath = resolveRepositoryPath(source.repository, to);
+						const outsideSource = source.file
+							? currentPath !== source.path || !isWithin(source.routeRoot, previousPath)
+							: !isWithin(source.path, previousPath) || !isWithin(source.path, currentPath);
+						if (outsideSource) continue;
+						if (!(await isFile(currentPath))) continue;
+
+						const redirectFrom = toRoute(source, previousPath);
+						const redirectTo = toRoute(source, currentPath);
+						if (
+							redirectFrom === redirectTo ||
+							currentRoutes.has(redirectFrom) ||
+							Object.hasOwn(existingRedirects, redirectFrom) ||
+							Object.hasOwn(generatedRedirects, redirectFrom)
+						) {
+							continue;
+						}
+
+						generatedRedirects[redirectFrom] = redirectTo;
+					}
+				}
+
+				updateConfig({ redirects: generatedRedirects });
+			},
+		},
+	};
+}
+
+async function resolveSource(root: string, source: GitRedirectSource): Promise<ResolvedSource> {
+	const sourcePath = path.resolve(root, source.path);
+	const sourceStat = await getSourceStat(sourcePath);
+	const file = sourceStat.isFile();
+	const routeRoot = file ? path.dirname(sourcePath) : sourcePath;
+	const repository = await getRepository(routeRoot, sourcePath);
+
+	if (!isWithin(repository, sourcePath)) {
+		throw new Error(
+			`@inox-tools/git-redirect: source path ${source.path} is outside its containing Git repository (${repository}).`
+		);
+	}
+
+	return { path: sourcePath, prefix: source.prefix, routeRoot, repository, file };
+}
+
+async function getSourceStat(sourcePath: string) {
+	try {
+		return await stat(sourcePath);
+	} catch (error) {
+		throw new Error(
+			`@inox-tools/git-redirect: source path ${sourcePath} cannot be read. Configure an existing file or directory.`,
+			{ cause: error }
+		);
+	}
+}
+
+async function getRepository(directory: string, sourcePath: string): Promise<string> {
+	const output = await runGit(
+		directory,
+		['rev-parse', '--show-toplevel'],
+		'find the containing repository'
+	);
+	const repositoryPath = output.toString('utf8').replace(/[\r\n]+$/, '');
+
+	if (!repositoryPath) {
+		throw new Error(
+			`@inox-tools/git-redirect: Git did not return a repository for source path ${sourcePath}.`
+		);
+	}
+
+	return path.resolve(repositoryPath);
+}
+
+async function getRepositoryRenames(
+	sources: ResolvedSource[]
+): Promise<Map<string, Map<string, string>>> {
+	const repositories = new Set(sources.map((source) => source.repository));
+	const entries = await Promise.all(
+		[...repositories].map(
+			async (repository) => [repository, await getRenameTargets(repository)] as const
+		)
+	);
+
+	return new Map(entries);
+}
+
+async function getRenameTargets(repository: string): Promise<Map<string, string>> {
+	const output = await runGit(
+		repository,
+		[
+			'log',
+			'--format=%x00',
+			'--name-status',
+			'-z',
+			'--find-renames',
+			'--diff-filter=R',
+			'HEAD',
+			'--',
+		],
+		'inspect rename history at HEAD'
+	);
+
+	const targets = new Map<string, string>();
+	for (const rename of parseRenames(output)) {
+		if (targets.has(rename.from)) continue;
+		targets.set(rename.from, targets.get(rename.to) ?? rename.to);
+	}
+
+	return targets;
+}
+
+function parseRenames(output: Buffer): Rename[] {
+	const fields = splitNulFields(output);
+	const renames: Rename[] = [];
+
+	for (let index = 0; index < fields.length; index += 1) {
+		const status = fields[index].trim();
+		if (!/^R\d+$/.test(status)) continue;
+
+		const from = fields[index + 1];
+		const to = fields[index + 2];
+		if (from === undefined || to === undefined) {
+			throw new Error('@inox-tools/git-redirect: Git returned an incomplete rename record.');
+		}
+
+		renames.push({ from, to });
+		index += 2;
+	}
+
+	return renames;
+}
+
+function splitNulFields(output: Buffer): string[] {
+	const fields: string[] = [];
+	let start = 0;
+
+	for (let end = output.indexOf(0, start); end !== -1; end = output.indexOf(0, start)) {
+		fields.push(output.subarray(start, end).toString('utf8'));
+		start = end + 1;
+	}
+
+	if (start < output.length) fields.push(output.subarray(start).toString('utf8'));
+	return fields;
+}
+
+async function getCurrentRoutes(source: ResolvedSource): Promise<Set<string>> {
+	const files = await getSourceFiles(source.path);
+	return new Set(files.filter(hasSupportedExtension).map((file) => toRoute(source, file)));
+}
+
+async function getSourceFiles(sourcePath: string): Promise<string[]> {
+	const sourceStat = await stat(sourcePath);
+	if (sourceStat.isFile()) return [sourcePath];
+	if (!sourceStat.isDirectory()) return [];
+
+	const files: string[] = [];
+	for (const entry of await readdir(sourcePath, { withFileTypes: true })) {
+		const entryPath = path.join(sourcePath, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...(await getSourceFiles(entryPath)));
+		} else if (entry.isFile()) {
+			files.push(entryPath);
+		}
+	}
+
+	return files;
+}
+
+function hasSupportedExtension(filePath: string): boolean {
+	const extension = path.extname(filePath);
+	return Object.hasOwn(supportedExtensions, extension);
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+	try {
+		return (await stat(filePath)).isFile();
+	} catch (error: unknown) {
+		if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+			return false;
+		}
+		throw new Error(`@inox-tools/git-redirect: cannot inspect current file ${filePath}.`, {
+			cause: error,
+		});
+	}
+}
+
+function resolveRepositoryPath(repository: string, gitPath: string): string {
+	const resolved = path.resolve(repository, ...gitPath.split('/'));
+	if (!isWithin(repository, resolved)) {
+		throw new Error(
+			`@inox-tools/git-redirect: Git returned a path outside the repository: ${gitPath}.`
+		);
+	}
+
+	return resolved;
+}
+
+function isWithin(parent: string, child: string): boolean {
+	const relative = path.relative(parent, child);
+	return (
+		relative === '' ||
+		(!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+	);
+}
+
+function toRoute(source: ResolvedSource, filePath: string): string {
+	const relative = path.relative(source.routeRoot, filePath);
+	const withoutExtension = relative.slice(0, -path.extname(relative).length);
+	const segments = withoutExtension.split(path.sep);
+	if (segments.at(-1) === 'index') segments.pop();
+
+	return path.posix.join(normalizePrefix(source.prefix), ...segments);
+}
+
+function normalizePrefix(prefix: string): string {
+	const normalized = path.posix.normalize(`/${prefix}`);
+	return normalized === '/' ? normalized : normalized.replace(/\/+$/, '');
+}
+
+async function runGit(directory: string, args: string[], action: string): Promise<Buffer> {
+	const command = ['git', '-C', directory, ...args].join(' ');
+	const child = spawn('git', ['-C', directory, ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+	const stdout: Buffer[] = [];
+	const stderr: Buffer[] = [];
+
+	child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+	child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+
+	let code: number | null;
+	let signal: NodeJS.Signals | null;
+	try {
+		[code, signal] = (await once(child, 'close')) as [number | null, NodeJS.Signals | null];
+	} catch (error) {
+		throw new Error(
+			`@inox-tools/git-redirect: failed to ${action}. Ensure Git is installed and ${directory} is accessible. (${command})`,
+			{ cause: error }
+		);
+	}
+
+	if (code === 0) return Buffer.concat(stdout);
+
+	const detail = Buffer.concat(stderr).toString('utf8').trim();
+	throw new Error(
+		`@inox-tools/git-redirect: failed to ${action} in ${directory}${
+			code === null ? ` (terminated by ${signal ?? 'an unknown signal'})` : ` (exit code ${code})`
+		}.${detail ? ` ${detail}` : ''} Command: ${command}`
+	);
+}

--- a/packages/git-redirect/src/index.ts
+++ b/packages/git-redirect/src/index.ts
@@ -11,8 +11,22 @@ const supportedExtensions: Record<string, true> = {
 	'.mdx': true,
 };
 
+/**
+ * A path whose Git rename history generates Astro redirects.
+ */
 export interface GitRedirectSource {
+	/**
+	 * An existing file or directory, resolved relative to the Astro project root (unless absolute).
+	 *
+	 * A file generates redirects for that page; a directory generates redirects for supported pages within it.
+	 */
 	path: string;
+	/**
+	 * The URL prefix for generated routes.
+	 *
+	 * It is normalized to a leading slash, with trailing slashes removed except for the root,
+	 * before being joined to page routes.
+	 */
 	prefix: string;
 }
 
@@ -33,6 +47,14 @@ type HistoryCommit = {
 	entries: HistoryEntry[];
 };
 
+/**
+ * Creates an Astro integration that generates redirects from Git rename history.
+ *
+ * Sources may be files or directories and are processed in order; for a generated-route collision, the
+ * earlier source wins. Existing routes and explicitly configured redirects always take precedence.
+ *
+ * Each source's containing repository must have complete, non-shallow history available at build time.
+ */
 export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegration {
 	return {
 		name: '@inox-tools/git-redirect',

--- a/packages/git-redirect/src/index.ts
+++ b/packages/git-redirect/src/index.ts
@@ -1,14 +1,22 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
-import { stat, readdir } from 'node:fs/promises';
+import { realpath, readdir, stat } from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { AstroIntegration } from 'astro';
 
 const supportedExtensions: Record<string, true> = {
 	'.astro': true,
+	'.html': true,
 	'.md': true,
 	'.mdx': true,
+	'.markdown': true,
+	'.mdown': true,
+	'.mkdn': true,
+	'.mkd': true,
+	'.mdwn': true,
+	'.js': true,
+	'.ts': true,
 };
 
 /**
@@ -67,12 +75,14 @@ export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegrat
 					sources.map((source) => resolveSource(root, pagesRoot, source))
 				);
 				const sourceFiles = await Promise.all(
-					resolvedSources.map((source) => getSourceFiles(source.path, source.pagesRoot))
+					resolvedSources.map((source) =>
+						getSourceFiles(source.path, source.pagesRoot, source.repository)
+					)
 				);
 				const historiesByRepository = await getRepositoryHistories(resolvedSources);
 				const existingRedirects = config.redirects ?? {};
 				const generatedRedirects: Record<string, string> = {};
-				const currentRoutes = new Set<string>();
+				const currentRoutes = await getAstroPageRoutes(pagesRoot, root);
 				for (const routes of await Promise.all(resolvedSources.map(getCurrentRoutes))) {
 					for (const route of routes) currentRoutes.add(route);
 				}
@@ -125,11 +135,12 @@ async function resolveSource(
 ): Promise<ResolvedSource> {
 	const sourcePath = path.resolve(root, source.path);
 	const sourceStat = await getSourceStat(sourcePath);
+	const sourceRealPath = await realpath(sourcePath);
 	const file = sourceStat.isFile();
 	const routeRoot = file ? path.dirname(sourcePath) : sourcePath;
 	const repository = await getRepository(routeRoot, sourcePath);
 
-	if (!isWithin(repository, sourcePath)) {
+	if (!isWithin(repository, sourcePath) || !isWithin(await realpath(repository), sourceRealPath)) {
 		throw new Error(
 			`@inox-tools/git-redirect: source path ${source.path} is outside its containing Git repository (${repository}).`
 		);
@@ -205,6 +216,7 @@ async function getRepositoryHistory(repository: string): Promise<HistoryCommit[]
 			'--format=%x00%H%x00',
 			'--name-status',
 			'-z',
+			'-l0',
 			'--find-renames',
 			'--diff-filter=ARD',
 			'--first-parent',
@@ -323,40 +335,100 @@ function splitNulFields(output: Buffer): string[] {
 	return fields;
 }
 
+async function getAstroPageRoutes(pagesRoot: string, root: string): Promise<Set<string>> {
+	try {
+		let repository = root;
+		try {
+			repository = await getRepository(root, root);
+		} catch {
+			repository = root;
+		}
+		const files = await getSourceFiles(pagesRoot, pagesRoot, repository);
+		return new Set(
+			files
+				.filter(hasSupportedExtension)
+				.map((file) => toRoute({ prefix: '/', routeRoot: pagesRoot }, file))
+		);
+	} catch (error: unknown) {
+		if (isNotFound(error)) return new Set();
+		throw error;
+	}
+}
+
 async function getCurrentRoutes(source: ResolvedSource): Promise<Set<string>> {
-	const files = await getSourceFiles(source.routeRoot, source.pagesRoot);
+	const files = await getSourceFiles(source.routeRoot, source.pagesRoot, source.repository);
 	return new Set(files.filter(hasSupportedExtension).map((file) => toRoute(source, file)));
 }
 
-async function getSourceFiles(sourcePath: string, pagesRoot?: string): Promise<string[]> {
-	if (
-		pagesRoot &&
-		path
-			.relative(pagesRoot, sourcePath)
-			.split(path.sep)
-			.some((segment) => segment.startsWith('_'))
-	) {
-		return [];
+async function getSourceFiles(
+	sourcePath: string,
+	pagesRoot?: string,
+	repository?: string
+): Promise<string[]> {
+	return collectSourceFiles(
+		sourcePath,
+		pagesRoot,
+		repository ? await realpath(repository) : undefined,
+		new Set()
+	);
+}
+
+async function collectSourceFiles(
+	sourcePath: string,
+	pagesRoot: string | undefined,
+	repository: string | undefined,
+	ancestors: ReadonlySet<string>
+): Promise<string[]> {
+	if (!isIncludedPagePath(sourcePath, pagesRoot)) return [];
+
+	let realSourcePath: string;
+	try {
+		realSourcePath = await realpath(sourcePath);
+	} catch (error: unknown) {
+		if (isNotFound(error)) return [];
+		throw error;
 	}
+	if (repository && !isWithin(repository, realSourcePath)) return [];
 
 	const sourceStat = await stat(sourcePath);
 	if (sourceStat.isFile()) return [sourcePath];
-	if (!sourceStat.isDirectory()) return [];
+	if (!sourceStat.isDirectory() || ancestors.has(realSourcePath)) return [];
 
+	const nextAncestors = new Set(ancestors).add(realSourcePath);
 	const files: string[] = [];
 	for (const entry of await readdir(sourcePath, { withFileTypes: true })) {
-		if (entry.name === '.git' || (pagesRoot && entry.name.startsWith('_'))) continue;
+		if (
+			entry.name === '.git' ||
+			(pagesRoot &&
+				(entry.name.startsWith('_') ||
+					(entry.name.startsWith('.') && entry.name !== '.well-known')))
+		) {
+			continue;
+		}
 
 		const entryPath = path.join(sourcePath, entry.name);
-		if (entry.isDirectory()) {
+		const entryStat = await stat(entryPath);
+		if (entryStat.isDirectory()) {
 			if (await hasGitMetadata(entryPath)) continue;
-			files.push(...(await getSourceFiles(entryPath, pagesRoot)));
-		} else if (entry.isFile()) {
-			files.push(entryPath);
+			files.push(...(await collectSourceFiles(entryPath, pagesRoot, repository, nextAncestors)));
+		} else if (entryStat.isFile()) {
+			files.push(...(await collectSourceFiles(entryPath, pagesRoot, repository, nextAncestors)));
 		}
 	}
 
 	return files;
+}
+
+function isIncludedPagePath(sourcePath: string, pagesRoot?: string): boolean {
+	if (!pagesRoot || !isWithin(pagesRoot, sourcePath)) return true;
+
+	return path
+		.relative(pagesRoot, sourcePath)
+		.split(path.sep)
+		.every(
+			(segment) =>
+				!segment.startsWith('_') && (!segment.startsWith('.') || segment === '.well-known')
+		);
 }
 
 async function hasGitMetadata(directory: string): Promise<boolean> {
@@ -434,7 +506,7 @@ function isWithin(parent: string, child: string): boolean {
 	);
 }
 
-function toRoute(source: ResolvedSource, filePath: string): string {
+function toRoute(source: Pick<ResolvedSource, 'prefix' | 'routeRoot'>, filePath: string): string {
 	const relative = path.relative(source.routeRoot, filePath);
 	const withoutExtension = relative.slice(0, -path.extname(relative).length);
 	const segments = withoutExtension.split(path.sep);

--- a/packages/git-redirect/src/index.ts
+++ b/packages/git-redirect/src/index.ts
@@ -36,6 +36,7 @@ type ResolvedSource = {
 	routeRoot: string;
 	repository: string;
 	file: boolean;
+	pagesRoot?: string;
 };
 
 type HistoryEntry =
@@ -61,11 +62,12 @@ export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegrat
 		hooks: {
 			'astro:config:setup': async ({ config, updateConfig }) => {
 				const root = fileURLToPath(config.root);
+				const pagesRoot = path.join(fileURLToPath(config.srcDir), 'pages');
 				const resolvedSources = await Promise.all(
-					sources.map((source) => resolveSource(root, source))
+					sources.map((source) => resolveSource(root, pagesRoot, source))
 				);
 				const sourceFiles = await Promise.all(
-					resolvedSources.map((source) => getSourceFiles(source.path))
+					resolvedSources.map((source) => getSourceFiles(source.path, source.pagesRoot))
 				);
 				const historiesByRepository = await getRepositoryHistories(resolvedSources);
 				const existingRedirects = config.redirects ?? {};
@@ -116,7 +118,11 @@ export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegrat
 	};
 }
 
-async function resolveSource(root: string, source: GitRedirectSource): Promise<ResolvedSource> {
+async function resolveSource(
+	root: string,
+	pagesRoot: string,
+	source: GitRedirectSource
+): Promise<ResolvedSource> {
 	const sourcePath = path.resolve(root, source.path);
 	const sourceStat = await getSourceStat(sourcePath);
 	const file = sourceStat.isFile();
@@ -129,7 +135,14 @@ async function resolveSource(root: string, source: GitRedirectSource): Promise<R
 		);
 	}
 
-	return { path: sourcePath, prefix: source.prefix, routeRoot, repository, file };
+	return {
+		path: sourcePath,
+		prefix: source.prefix,
+		routeRoot,
+		repository,
+		file,
+		pagesRoot: isWithin(pagesRoot, sourcePath) ? pagesRoot : undefined,
+	};
 }
 
 async function getSourceStat(sourcePath: string) {
@@ -267,11 +280,15 @@ function resolveRenameTargets(
 	for (const currentPath of currentPaths) paths.set(currentPath, currentPath);
 
 	const targets = new Map<string, string>();
+	const birthsCrossed = new Set<string>();
 	for (const commit of commits) {
 		const before = new Map(paths);
 
 		for (const entry of commit.entries) {
-			if (entry.kind === 'add') before.delete(entry.path);
+			if (entry.kind === 'add') {
+				before.delete(entry.path);
+				birthsCrossed.add(entry.path);
+			}
 		}
 		for (const entry of commit.entries) {
 			if (entry.kind === 'delete') before.set(entry.path, undefined);
@@ -282,7 +299,7 @@ function resolveRenameTargets(
 			const target = paths.get(entry.to);
 			before.delete(entry.to);
 			before.set(entry.from, target);
-			if (target !== undefined && !targets.has(entry.from)) {
+			if (target !== undefined && !targets.has(entry.from) && !birthsCrossed.has(entry.from)) {
 				targets.set(entry.from, target);
 			}
 		}
@@ -307,23 +324,33 @@ function splitNulFields(output: Buffer): string[] {
 }
 
 async function getCurrentRoutes(source: ResolvedSource): Promise<Set<string>> {
-	const files = await getSourceFiles(source.routeRoot);
+	const files = await getSourceFiles(source.routeRoot, source.pagesRoot);
 	return new Set(files.filter(hasSupportedExtension).map((file) => toRoute(source, file)));
 }
 
-async function getSourceFiles(sourcePath: string): Promise<string[]> {
+async function getSourceFiles(sourcePath: string, pagesRoot?: string): Promise<string[]> {
+	if (
+		pagesRoot &&
+		path
+			.relative(pagesRoot, sourcePath)
+			.split(path.sep)
+			.some((segment) => segment.startsWith('_'))
+	) {
+		return [];
+	}
+
 	const sourceStat = await stat(sourcePath);
 	if (sourceStat.isFile()) return [sourcePath];
 	if (!sourceStat.isDirectory()) return [];
 
 	const files: string[] = [];
 	for (const entry of await readdir(sourcePath, { withFileTypes: true })) {
-		if (entry.name === '.git') continue;
+		if (entry.name === '.git' || (pagesRoot && entry.name.startsWith('_'))) continue;
 
 		const entryPath = path.join(sourcePath, entry.name);
 		if (entry.isDirectory()) {
 			if (await hasGitMetadata(entryPath)) continue;
-			files.push(...(await getSourceFiles(entryPath)));
+			files.push(...(await getSourceFiles(entryPath, pagesRoot)));
 		} else if (entry.isFile()) {
 			files.push(entryPath);
 		}

--- a/packages/git-redirect/src/index.ts
+++ b/packages/git-redirect/src/index.ts
@@ -24,9 +24,13 @@ type ResolvedSource = {
 	file: boolean;
 };
 
-type Rename = {
-	from: string;
-	to: string;
+type HistoryEntry =
+	| { kind: 'add'; path: string }
+	| { kind: 'delete'; path: string }
+	| { kind: 'rename'; from: string; to: string };
+
+type HistoryCommit = {
+	entries: HistoryEntry[];
 };
 
 export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegration {
@@ -38,7 +42,10 @@ export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegrat
 				const resolvedSources = await Promise.all(
 					sources.map((source) => resolveSource(root, source))
 				);
-				const renamesByRepository = await getRepositoryRenames(resolvedSources);
+				const sourceFiles = await Promise.all(
+					resolvedSources.map((source) => getSourceFiles(source.path))
+				);
+				const historiesByRepository = await getRepositoryHistories(resolvedSources);
 				const existingRedirects = config.redirects ?? {};
 				const generatedRedirects: Record<string, string> = {};
 				const currentRoutes = new Set<string>();
@@ -46,10 +53,14 @@ export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegrat
 					for (const route of routes) currentRoutes.add(route);
 				}
 
-				for (const source of resolvedSources) {
-					const renames = renamesByRepository.get(source.repository);
-					if (!renames) continue;
+				for (const [index, source] of resolvedSources.entries()) {
+					const history = historiesByRepository.get(source.repository);
+					if (!history) continue;
 
+					const currentPaths = sourceFiles[index].map((file) =>
+						toRepositoryPath(source.repository, file)
+					);
+					const renames = resolveRenameTargets(history, currentPaths);
 					for (const [from, to] of renames) {
 						if (!hasSupportedExtension(from) || !hasSupportedExtension(to)) continue;
 
@@ -65,6 +76,7 @@ export default function gitRedirect(sources: GitRedirectSource[]): AstroIntegrat
 						const redirectTo = toRoute(source, currentPath);
 						if (
 							redirectFrom === redirectTo ||
+							!hasMatchingParameterBindings(redirectFrom, redirectTo) ||
 							currentRoutes.has(redirectFrom) ||
 							Object.hasOwn(existingRedirects, redirectFrom) ||
 							Object.hasOwn(generatedRedirects, redirectFrom)
@@ -126,63 +138,137 @@ async function getRepository(directory: string, sourcePath: string): Promise<str
 	return path.resolve(repositoryPath);
 }
 
-async function getRepositoryRenames(
+async function getRepositoryHistories(
 	sources: ResolvedSource[]
-): Promise<Map<string, Map<string, string>>> {
+): Promise<Map<string, HistoryCommit[]>> {
 	const repositories = new Set(sources.map((source) => source.repository));
 	const entries = await Promise.all(
 		[...repositories].map(
-			async (repository) => [repository, await getRenameTargets(repository)] as const
+			async (repository) => [repository, await getRepositoryHistory(repository)] as const
 		)
 	);
 
 	return new Map(entries);
 }
 
-async function getRenameTargets(repository: string): Promise<Map<string, string>> {
+async function getRepositoryHistory(repository: string): Promise<HistoryCommit[]> {
+	const shallow = await runGit(
+		repository,
+		['rev-parse', '--is-shallow-repository'],
+		'check whether Git history is complete'
+	);
+	if (shallow.toString('utf8').trim() === 'true') {
+		throw new Error(
+			`@inox-tools/git-redirect: repository ${repository} has shallow Git history. Fetch the full history before building redirects (for GitHub Actions, set fetch-depth: 0).`
+		);
+	}
+
 	const output = await runGit(
 		repository,
 		[
 			'log',
-			'--format=%x00',
+			'--format=%x00%H%x00',
 			'--name-status',
 			'-z',
 			'--find-renames',
-			'--diff-filter=R',
+			'--diff-filter=ARD',
+			'--first-parent',
+			'--diff-merges=first-parent',
 			'HEAD',
 			'--',
 		],
-		'inspect rename history at HEAD'
+		'inspect first-parent rename history at HEAD'
 	);
 
+	return parseHistory(output);
+}
+
+function parseHistory(output: Buffer): HistoryCommit[] {
+	const fields = splitNulFields(output);
+	const commits: HistoryCommit[] = [];
+	let index = 0;
+
+	while (index < fields.length) {
+		if (!isCommitFrame(fields, index)) {
+			throw new Error('@inox-tools/git-redirect: Git returned malformed commit history.');
+		}
+		index += 3;
+
+		const entries: HistoryEntry[] = [];
+		while (index < fields.length && !isCommitFrame(fields, index)) {
+			const status = fields[index].trim();
+			if (status === 'A' || status === 'D') {
+				const filePath = fields[index + 1];
+				if (filePath === undefined) {
+					throw new Error('@inox-tools/git-redirect: Git returned an incomplete history entry.');
+				}
+				entries.push({ kind: status === 'A' ? 'add' : 'delete', path: filePath });
+				index += 2;
+				continue;
+			}
+
+			if (/^R\d+$/.test(status)) {
+				const from = fields[index + 1];
+				const to = fields[index + 2];
+				if (from === undefined || to === undefined) {
+					throw new Error('@inox-tools/git-redirect: Git returned an incomplete rename record.');
+				}
+				entries.push({ kind: 'rename', from, to });
+				index += 3;
+				continue;
+			}
+
+			throw new Error(
+				`@inox-tools/git-redirect: Git returned an unsupported history status: ${status}.`
+			);
+		}
+
+		commits.push({ entries });
+	}
+
+	return commits;
+}
+
+function isCommitFrame(fields: string[], index: number): boolean {
+	return (
+		fields[index] === '' &&
+		/^[0-9a-f]{40,64}$/i.test(fields[index + 1] ?? '') &&
+		fields[index + 2] === ''
+	);
+}
+
+function resolveRenameTargets(
+	commits: HistoryCommit[],
+	currentPaths: Iterable<string>
+): Map<string, string> {
+	let paths = new Map<string, string | undefined>();
+	for (const currentPath of currentPaths) paths.set(currentPath, currentPath);
+
 	const targets = new Map<string, string>();
-	for (const rename of parseRenames(output)) {
-		if (targets.has(rename.from)) continue;
-		targets.set(rename.from, targets.get(rename.to) ?? rename.to);
+	for (const commit of commits) {
+		const before = new Map(paths);
+
+		for (const entry of commit.entries) {
+			if (entry.kind === 'add') before.delete(entry.path);
+		}
+		for (const entry of commit.entries) {
+			if (entry.kind === 'delete') before.set(entry.path, undefined);
+		}
+		for (const entry of commit.entries) {
+			if (entry.kind !== 'rename') continue;
+
+			const target = paths.get(entry.to);
+			before.delete(entry.to);
+			before.set(entry.from, target);
+			if (target !== undefined && !targets.has(entry.from)) {
+				targets.set(entry.from, target);
+			}
+		}
+
+		paths = before;
 	}
 
 	return targets;
-}
-
-function parseRenames(output: Buffer): Rename[] {
-	const fields = splitNulFields(output);
-	const renames: Rename[] = [];
-
-	for (let index = 0; index < fields.length; index += 1) {
-		const status = fields[index].trim();
-		if (!/^R\d+$/.test(status)) continue;
-
-		const from = fields[index + 1];
-		const to = fields[index + 2];
-		if (from === undefined || to === undefined) {
-			throw new Error('@inox-tools/git-redirect: Git returned an incomplete rename record.');
-		}
-
-		renames.push({ from, to });
-		index += 2;
-	}
-
-	return renames;
 }
 
 function splitNulFields(output: Buffer): string[] {
@@ -199,7 +285,7 @@ function splitNulFields(output: Buffer): string[] {
 }
 
 async function getCurrentRoutes(source: ResolvedSource): Promise<Set<string>> {
-	const files = await getSourceFiles(source.path);
+	const files = await getSourceFiles(source.routeRoot);
 	return new Set(files.filter(hasSupportedExtension).map((file) => toRoute(source, file)));
 }
 
@@ -210,8 +296,11 @@ async function getSourceFiles(sourcePath: string): Promise<string[]> {
 
 	const files: string[] = [];
 	for (const entry of await readdir(sourcePath, { withFileTypes: true })) {
+		if (entry.name === '.git') continue;
+
 		const entryPath = path.join(sourcePath, entry.name);
 		if (entry.isDirectory()) {
+			if (await hasGitMetadata(entryPath)) continue;
 			files.push(...(await getSourceFiles(entryPath)));
 		} else if (entry.isFile()) {
 			files.push(entryPath);
@@ -219,6 +308,46 @@ async function getSourceFiles(sourcePath: string): Promise<string[]> {
 	}
 
 	return files;
+}
+
+async function hasGitMetadata(directory: string): Promise<boolean> {
+	try {
+		await stat(path.join(directory, '.git'));
+		return true;
+	} catch (error: unknown) {
+		if (isNotFound(error)) return false;
+		throw new Error(`@inox-tools/git-redirect: cannot inspect nested repository ${directory}.`, {
+			cause: error,
+		});
+	}
+}
+
+function hasMatchingParameterBindings(from: string, to: string): boolean {
+	const fromBindings = [...from.matchAll(/\[(\.\.\.)?([^/\]]+)\]/g)].map(
+		(match) => `${match[1] ?? ''}${match[2]}`
+	);
+	const toBindings = [...to.matchAll(/\[(\.\.\.)?([^/\]]+)\]/g)].map(
+		(match) => `${match[1] ?? ''}${match[2]}`
+	);
+	return (
+		fromBindings.length === toBindings.length &&
+		fromBindings.every((binding, index) => binding === toBindings[index])
+	);
+}
+
+function toRepositoryPath(repository: string, filePath: string): string {
+	const relative = path.relative(repository, filePath);
+	if (!relative || !isWithin(repository, filePath)) {
+		throw new Error(
+			`@inox-tools/git-redirect: current file is outside the repository: ${filePath}.`
+		);
+	}
+
+	return relative.split(path.sep).join('/');
+}
+
+function isNotFound(error: unknown): error is { code: 'ENOENT' } {
+	return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
 }
 
 function hasSupportedExtension(filePath: string): boolean {
@@ -230,9 +359,7 @@ async function isFile(filePath: string): Promise<boolean> {
 	try {
 		return (await stat(filePath)).isFile();
 	} catch (error: unknown) {
-		if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
-			return false;
-		}
+		if (isNotFound(error)) return false;
 		throw new Error(`@inox-tools/git-redirect: cannot inspect current file ${filePath}.`, {
 			cause: error,
 		});

--- a/packages/git-redirect/tests/git-redirect.test.ts
+++ b/packages/git-redirect/tests/git-redirect.test.ts
@@ -1,0 +1,247 @@
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import { describe, expect, test } from 'vitest';
+import gitRedirect, { type GitRedirectSource } from '../src/index.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(repository: string, ...args: string[]) {
+	await execFileAsync('git', args, { cwd: repository });
+}
+
+async function createFile(repository: string, file: string, content: string) {
+	const path = join(repository, file);
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, content);
+}
+
+async function commit(repository: string, message: string) {
+	await git(repository, 'add', '--all');
+	await git(repository, 'commit', '--message', message);
+}
+
+async function moveFile(repository: string, from: string, to: string) {
+	await mkdir(dirname(join(repository, to)), { recursive: true });
+	await git(repository, 'mv', from, to);
+}
+
+async function withRepository(callback: (repository: string) => Promise<void>) {
+	const repository = await mkdtemp(join(tmpdir(), 'inox-git-redirect-'));
+
+	try {
+		await git(repository, 'init', '--initial-branch=main');
+		await git(repository, 'config', 'user.email', 'tests@inox.tools');
+		await git(repository, 'config', 'user.name', 'Inox Tests');
+		await callback(repository);
+	} finally {
+		await rm(repository, { recursive: true, force: true });
+	}
+}
+
+async function resolveRedirects(
+	repository: string,
+	sources: GitRedirectSource[],
+	existingRedirects: Record<string, string> = {}
+) {
+	const integration = gitRedirect(sources);
+	const hook = integration.hooks['astro:config:setup'];
+	const updates: Array<{ redirects?: Record<string, string> }> = [];
+
+	expect(hook).toBeDefined();
+	await hook?.({
+		config: {
+			redirects: existingRedirects,
+			root: pathToFileURL(`${repository}/`),
+		},
+		updateConfig: (update: { redirects?: Record<string, string> }) => updates.push(update),
+	} as never);
+
+	return updates.reduce((redirects, update) => Object.assign(redirects, update.redirects), {
+		...existingRedirects,
+	});
+}
+
+describe('gitRedirect', () => {
+	test('creates redirects for renamed Astro, Markdown, and MDX files', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'content/astro/old.astro', '<h1>Astro</h1>');
+			await createFile(repository, 'content/markdown/old.md', '# Markdown');
+			await createFile(repository, 'content/mdx/old.mdx', '# MDX');
+			await commit(repository, 'add original pages');
+
+			await moveFile(repository, 'content/astro/old.astro', 'content/astro/current.astro');
+			await moveFile(repository, 'content/markdown/old.md', 'content/markdown/current.md');
+			await moveFile(repository, 'content/mdx/old.mdx', 'content/mdx/current.mdx');
+			await commit(repository, 'rename pages');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'content', prefix: '/guides/' }])
+			).resolves.toEqual({
+				'/guides/astro/old': '/guides/astro/current',
+				'/guides/markdown/old': '/guides/markdown/current',
+				'/guides/mdx/old': '/guides/mdx/current',
+			});
+		});
+	});
+
+	test('follows rename chains to the current file', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/original.astro', '<h1>Original</h1>');
+			await commit(repository, 'add original page');
+
+			await moveFile(repository, 'pages/original.astro', 'pages/intermediate.astro');
+			await commit(repository, 'rename page once');
+
+			await moveFile(repository, 'pages/intermediate.astro', 'pages/current.mdx');
+			await commit(repository, 'rename page twice');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/original': '/docs/current',
+				'/docs/intermediate': '/docs/current',
+			});
+		});
+	});
+
+	test('uses the latest rename when a historical path is reused', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/reused.md', '# Original');
+			await commit(repository, 'add original page');
+
+			await moveFile(repository, 'pages/reused.md', 'pages/first-current.md');
+			await commit(repository, 'rename original page');
+
+			await createFile(repository, 'pages/reused.md', '# Replacement');
+			await commit(repository, 'reuse original path');
+
+			await moveFile(repository, 'pages/reused.md', 'pages/latest-current.md');
+			await commit(repository, 'rename replacement page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/reused': '/docs/latest-current',
+			});
+		});
+	});
+
+	test('accepts a current file as the configured source path', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/old.mdx', '# Old');
+			await commit(repository, 'add old page');
+
+			await moveFile(repository, 'pages/old.mdx', 'pages/current.mdx');
+			await commit(repository, 'rename page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages/current.mdx', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/old': '/docs/current',
+			});
+		});
+	});
+
+	test('normalizes prefixes and collapses terminal index routes', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/previous/index.md', '# Previous');
+			await commit(repository, 'add previous index');
+
+			await moveFile(repository, 'pages/previous/index.md', 'pages/index.mdx');
+			await commit(repository, 'move index to root');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '///docs//' }])
+			).resolves.toEqual({
+				'/docs/previous': '/docs',
+			});
+		});
+	});
+
+	test('skips unsupported sources and URLs that are still current files', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/unsupported.txt', 'unsupported');
+			await createFile(repository, 'pages/old.astro', '<h1>Old</h1>');
+			await commit(repository, 'add pages');
+
+			await moveFile(repository, 'pages/unsupported.txt', 'pages/supported.astro');
+			await moveFile(repository, 'pages/old.astro', 'pages/new.astro');
+			await commit(repository, 'rename pages');
+
+			await createFile(repository, 'pages/old.astro', '<h1>Replacement</h1>');
+			await commit(repository, 'restore old URL');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/docs' }])
+			).resolves.toEqual({});
+		});
+	});
+
+	test('does not redirect a URL served by another configured source', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'first/page.md', '# Historical');
+			await createFile(repository, 'second/page.md', '# Current');
+			await commit(repository, 'add pages');
+
+			await moveFile(repository, 'first/page.md', 'first/renamed.md');
+			await commit(repository, 'rename historical page');
+
+			await expect(
+				resolveRedirects(repository, [
+					{ path: 'first', prefix: '/docs' },
+					{ path: 'second', prefix: '/docs' },
+				])
+			).resolves.toEqual({});
+		});
+	});
+
+	test('preserves explicit Astro redirects on collisions', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/old.astro', '<h1>Old</h1>');
+			await commit(repository, 'add old page');
+
+			await moveFile(repository, 'pages/old.astro', 'pages/generated.astro');
+			await commit(repository, 'rename page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/' }], { '/old': '/manual' })
+			).resolves.toEqual({ '/old': '/manual' });
+		});
+	});
+
+	test('gives earlier sources precedence when generated redirects collide', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'first/old.astro', '<h1>First</h1>');
+			await createFile(repository, 'second/old.astro', '<h1>Second</h1>');
+			await commit(repository, 'add old pages');
+
+			await moveFile(repository, 'first/old.astro', 'first/first-current.astro');
+			await moveFile(repository, 'second/old.astro', 'second/second-current.astro');
+			await commit(repository, 'rename pages');
+
+			await expect(
+				resolveRedirects(repository, [
+					{ path: 'first', prefix: '/docs' },
+					{ path: 'second', prefix: '/docs' },
+				])
+			).resolves.toEqual({ '/docs/old': '/docs/first-current' });
+		});
+	});
+
+	test('reports source paths outside a Git repository', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'inox-git-redirect-no-repository-'));
+
+		try {
+			await createFile(directory, 'pages/current.astro', '<h1>Current</h1>');
+			await expect(resolveRedirects(directory, [{ path: 'pages', prefix: '/' }])).rejects.toThrow(
+				/\b(git|repository)\b/i
+			);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/git-redirect/tests/git-redirect.test.ts
+++ b/packages/git-redirect/tests/git-redirect.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -17,6 +17,12 @@ async function createFile(repository: string, file: string, content: string) {
 	const path = join(repository, file);
 	await mkdir(dirname(path), { recursive: true });
 	await writeFile(path, content);
+}
+
+async function createSymlink(repository: string, file: string, target: string) {
+	const path = join(repository, file);
+	await mkdir(dirname(path), { recursive: true });
+	await symlink(target, path);
 }
 
 async function commit(repository: string, message: string) {
@@ -181,6 +187,106 @@ describe('gitRedirect', () => {
 			await expect(
 				resolveRedirects(repository, [{ path: pages, prefix: '/docs' }], {}, srcDir)
 			).resolves.toEqual({});
+		});
+	});
+
+	test('does not redirect a URL served by an unconfigured Astro endpoint', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'content/old.md', '# Old');
+			await createFile(repository, 'src/pages/old.ts', 'export function GET() {}');
+			await commit(repository, 'add pages');
+
+			await moveFile(repository, 'content/old.md', 'content/current.md');
+			await commit(repository, 'rename content page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'content', prefix: '/' }])
+			).resolves.toEqual({});
+		});
+	});
+
+	test('excludes hidden Astro pages while retaining .well-known pages', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'src/pages/hidden-old.md', '# Hidden');
+			await createFile(repository, 'src/pages/well-known-old.md', '# Well known');
+			await commit(repository, 'add pages');
+
+			await moveFile(repository, 'src/pages/hidden-old.md', 'src/pages/.hidden/current.md');
+			await moveFile(repository, 'src/pages/well-known-old.md', 'src/pages/.well-known/current.md');
+			await commit(repository, 'rename pages');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'src/pages', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/well-known-old': '/docs/.well-known/current',
+			});
+		});
+	});
+
+	test('creates redirects for renamed symlinked pages', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'src/pages/target.astro', '<h1>Target</h1>');
+			await createSymlink(repository, 'src/pages/old.astro', 'target.astro');
+			await commit(repository, 'add symlinked page');
+
+			await moveFile(repository, 'src/pages/old.astro', 'src/pages/current.astro');
+			await commit(repository, 'rename symlinked page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'src/pages', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/old': '/docs/current',
+			});
+		});
+	});
+
+	test('skips page symlinks outside the repository and directory cycles', async () => {
+		const external = await mkdtemp(join(tmpdir(), 'inox-git-redirect-external-'));
+
+		try {
+			await createFile(external, 'outside.md', '# Outside');
+			await withRepository(async (repository) => {
+				await createFile(repository, 'src/pages/old.md', '# Old');
+				await commit(repository, 'add page');
+
+				await moveFile(repository, 'src/pages/old.md', 'src/pages/current.md');
+				await commit(repository, 'rename page');
+				await createSymlink(repository, 'src/pages/external', external);
+				await createSymlink(repository, 'src/pages/cycle', '.');
+
+				await expect(
+					resolveRedirects(repository, [{ path: 'src/pages', prefix: '/docs' }])
+				).resolves.toEqual({
+					'/docs/old': '/docs/current',
+				});
+			});
+		} finally {
+			await rm(external, { recursive: true, force: true });
+		}
+	});
+
+	test('detects renames despite a low Git rename limit', async () => {
+		await withRepository(async (repository) => {
+			const original = `Original heading\n${'Shared page content.\n'.repeat(20)}`;
+			const replacement = `Replacement heading\n${'Shared page content.\n'.repeat(20)}`;
+			const otherOriginal = `Other original heading\n${'Other shared content.\n'.repeat(20)}`;
+			const otherReplacement = `Other replacement heading\n${'Other shared content.\n'.repeat(20)}`;
+			await createFile(repository, 'src/pages/old.md', original);
+			await createFile(repository, 'fixtures/old.txt', otherOriginal);
+			await commit(repository, 'add files');
+
+			await rm(join(repository, 'src/pages/old.md'));
+			await rm(join(repository, 'fixtures/old.txt'));
+			await createFile(repository, 'src/pages/current.md', replacement);
+			await createFile(repository, 'fixtures/current.txt', otherReplacement);
+			await git(repository, 'config', 'diff.renameLimit', '1');
+			await commit(repository, 'rename files');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'src/pages', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/old': '/docs/current',
+			});
 		});
 	});
 

--- a/packages/git-redirect/tests/git-redirect.test.ts
+++ b/packages/git-redirect/tests/git-redirect.test.ts
@@ -232,6 +232,149 @@ describe('gitRedirect', () => {
 		});
 	});
 
+	test('keeps rename chains within their original path lifetime', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/a.md', '# Original');
+			await commit(repository, 'add original page');
+
+			await moveFile(repository, 'pages/a.md', 'pages/b.md');
+			await commit(repository, 'rename original page once');
+
+			await moveFile(repository, 'pages/b.md', 'pages/c.md');
+			await commit(repository, 'rename original page twice');
+
+			await createFile(repository, 'pages/b.md', '# Replacement');
+			await commit(repository, 'reuse intermediate path');
+
+			await moveFile(repository, 'pages/b.md', 'pages/d.md');
+			await commit(repository, 'rename replacement page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/a': '/docs/c',
+				'/docs/b': '/docs/d',
+			});
+		});
+	});
+
+	test('only redirects dynamic routes with identical parameter bindings', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/renamed/[id].md', '# Renamed parameter');
+			await createFile(repository, 'pages/static/[id].md', '# Static parameter');
+			await createFile(repository, 'pages/rest/[...parts].md', '# Rest parameter');
+			await createFile(repository, 'pages/same/[id]/old.md', '# Compatible parameter');
+			await commit(repository, 'add dynamic pages');
+
+			await moveFile(repository, 'pages/renamed/[id].md', 'pages/renamed/[slug].md');
+			await moveFile(repository, 'pages/static/[id].md', 'pages/static/current.md');
+			await moveFile(repository, 'pages/rest/[...parts].md', 'pages/rest/[parts].md');
+			await moveFile(repository, 'pages/same/[id]/old.md', 'pages/same/[id]/current.md');
+			await commit(repository, 'rename dynamic pages');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/same/[id]/old': '/docs/same/[id]/current',
+			});
+		});
+	});
+
+	test('rejects shallow repositories with fetch-depth guidance', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/current.md', '# Current');
+			await commit(repository, 'add current page');
+
+			const shallowRepository = join(repository, 'shallow');
+			await git(
+				repository,
+				'clone',
+				'--depth=1',
+				pathToFileURL(repository).href,
+				shallowRepository
+			);
+
+			await expect(
+				resolveRedirects(shallowRepository, [{ path: 'pages', prefix: '/docs' }])
+			).rejects.toThrow(/fetch-depth:\s*0/i);
+		});
+	});
+
+	test('does not shadow recreated sibling routes for configured files', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/old.md', '# Old');
+			await commit(repository, 'add old page');
+
+			await moveFile(repository, 'pages/old.md', 'pages/current.md');
+			await commit(repository, 'rename page');
+
+			await createFile(repository, 'pages/old.md', '# Replacement');
+			await commit(repository, 'recreate sibling page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages/current.md', prefix: '/docs' }])
+			).resolves.toEqual({});
+		});
+	});
+
+	test('finds renames introduced by first-parent merge resolution', async () => {
+		await withRepository(async (repository) => {
+			const sharedContent = 'Shared content that makes this a detected rename.\n'.repeat(20);
+			await createFile(repository, 'pages/old.md', sharedContent);
+			await commit(repository, 'add original page');
+
+			await git(repository, 'checkout', '-b', 'feature');
+			await createFile(repository, 'pages/old.md', `Feature branch\n${sharedContent}`);
+			await commit(repository, 'change page on feature branch');
+
+			await git(repository, 'checkout', 'main');
+			await createFile(repository, 'pages/old.md', `Main branch\n${sharedContent}`);
+			await commit(repository, 'change page on main branch');
+
+			await expect(git(repository, 'merge', '--no-commit', 'feature')).rejects.toThrow();
+			await git(repository, 'rm', '--force', 'pages/old.md');
+			await createFile(repository, 'pages/current.md', sharedContent);
+			await commit(repository, 'resolve merge by renaming page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/old': '/docs/current',
+			});
+		});
+	});
+
+	test('requires nested repositories to be configured separately', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/nested/old.md', '# Parent page');
+			await commit(repository, 'add parent page');
+
+			await moveFile(repository, 'pages/nested/old.md', 'pages/nested/current.md');
+			await commit(repository, 'rename parent page');
+
+			const nestedRepository = join(repository, 'pages/nested');
+			await rm(nestedRepository, { recursive: true });
+			await mkdir(nestedRepository, { recursive: true });
+			await git(nestedRepository, 'init', '--initial-branch=main');
+			await git(nestedRepository, 'config', 'user.email', 'tests@inox.tools');
+			await git(nestedRepository, 'config', 'user.name', 'Inox Tests');
+			await createFile(nestedRepository, 'old.md', '# Nested page');
+			await commit(nestedRepository, 'add nested page');
+			await moveFile(nestedRepository, 'old.md', 'current.md');
+			await commit(nestedRepository, 'rename nested page');
+			await commit(repository, 'replace directory with nested repository');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/docs' }])
+			).resolves.toEqual({});
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages/nested', prefix: '/docs' }])
+			).resolves.toEqual({
+				'/docs/old': '/docs/current',
+			});
+		});
+	});
+
 	test('reports source paths outside a Git repository', async () => {
 		const directory = await mkdtemp(join(tmpdir(), 'inox-git-redirect-no-repository-'));
 

--- a/packages/git-redirect/tests/git-redirect.test.ts
+++ b/packages/git-redirect/tests/git-redirect.test.ts
@@ -45,7 +45,8 @@ async function withRepository(callback: (repository: string) => Promise<void>) {
 async function resolveRedirects(
 	repository: string,
 	sources: GitRedirectSource[],
-	existingRedirects: Record<string, string> = {}
+	existingRedirects: Record<string, string> = {},
+	srcDir = 'src'
 ) {
 	const integration = gitRedirect(sources);
 	const hook = integration.hooks['astro:config:setup'];
@@ -56,6 +57,7 @@ async function resolveRedirects(
 		config: {
 			redirects: existingRedirects,
 			root: pathToFileURL(`${repository}/`),
+			srcDir: pathToFileURL(`${repository}/${srcDir}/`),
 		},
 		updateConfig: (update: { redirects?: Record<string, string> }) => updates.push(update),
 	} as never);
@@ -130,6 +132,26 @@ describe('gitRedirect', () => {
 		});
 	});
 
+	test('does not redirect an older lifetime after its path is reused and deleted', async () => {
+		await withRepository(async (repository) => {
+			await createFile(repository, 'pages/old.md', '# Original');
+			await commit(repository, 'add original page');
+
+			await moveFile(repository, 'pages/old.md', 'pages/current.md');
+			await commit(repository, 'rename original page');
+
+			await createFile(repository, 'pages/old.md', '# Replacement');
+			await commit(repository, 'reuse old path');
+
+			await rm(join(repository, 'pages/old.md'));
+			await commit(repository, 'delete replacement page');
+
+			await expect(
+				resolveRedirects(repository, [{ path: 'pages', prefix: '/docs' }])
+			).resolves.toEqual({});
+		});
+	});
+
 	test('accepts a current file as the configured source path', async () => {
 		await withRepository(async (repository) => {
 			await createFile(repository, 'pages/old.mdx', '# Old');
@@ -143,6 +165,22 @@ describe('gitRedirect', () => {
 			).resolves.toEqual({
 				'/docs/old': '/docs/current',
 			});
+		});
+	});
+
+	test('excludes underscore-prefixed files in a custom Astro pages directory', async () => {
+		await withRepository(async (repository) => {
+			const srcDir = 'application';
+			const pages = `${srcDir}/pages`;
+			await createFile(repository, `${pages}/old.md`, '# Old');
+			await commit(repository, 'add page');
+
+			await moveFile(repository, `${pages}/old.md`, `${pages}/_draft.md`);
+			await commit(repository, 'move page to draft');
+
+			await expect(
+				resolveRedirects(repository, [{ path: pages, prefix: '/docs' }], {}, srcDir)
+			).resolves.toEqual({});
 		});
 	});
 

--- a/packages/git-redirect/tests/vitest.setup.ts
+++ b/packages/git-redirect/tests/vitest.setup.ts
@@ -1,0 +1,1 @@
+process.setSourceMapsEnabled(true);

--- a/packages/git-redirect/tsconfig.json
+++ b/packages/git-redirect/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/git-redirect/tsup.config.ts
+++ b/packages/git-redirect/tsup.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'tsup';
+import { readFileSync } from 'node:fs';
+
+const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
+const dependencies = [
+	...Object.keys(packageJson.dependencies || {}),
+	...Object.keys(packageJson.peerDependencies || {}),
+];
+const devDependencies = [...Object.keys(packageJson.devDependencies || {})];
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	format: ['esm'],
+	target: 'node18',
+	bundle: true,
+	dts: true,
+	sourcemap: true,
+	clean: true,
+	splitting: true,
+	minify: false,
+	external: dependencies,
+	noExternal: devDependencies,
+	treeshake: 'smallest',
+	tsconfig: 'tsconfig.json',
+	esbuildOptions: (options) => {
+		options.chunkNames = 'chunks/[name]-[hash]';
+	},
+});

--- a/packages/git-redirect/vitest.config.ts
+++ b/packages/git-redirect/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+process.env.NODE_OPTIONS ??= '--enable-source-maps';
+process.setSourceMapsEnabled(true);
+
+export default defineConfig({
+	test: {
+		fileParallelism: false,
+		setupFiles: ['./tests/vitest.setup.ts'],
+	},
+});

--- a/packages/request-state/e2e/dev.spec.ts
+++ b/packages/request-state/e2e/dev.spec.ts
@@ -22,10 +22,9 @@ test('apply new as edited during development', async ({ page }) => {
 	await page.goto(pageUrl);
 	await expect
 		.poll(async () => {
-			const state = JSON.parse(await page.locator('pre#state').innerHTML());
+			const content = await page.locator('pre#state').textContent();
 
-			console.log(state);
-			return state;
+			return content ? JSON.parse(content) : null;
 		})
 		.toStrictEqual({
 			source: 'Original',
@@ -34,7 +33,11 @@ test('apply new as edited during development', async ({ page }) => {
 	await fixture.editFile('./src/state.ts', (code) => (code ?? '').replace('Original', 'Updated'));
 
 	await expect
-		.poll(async () => JSON.parse(await page.locator('pre#state').innerHTML()))
+		.poll(async () => {
+			const content = await page.locator('pre#state').textContent();
+
+			return content ? JSON.parse(content) : null;
+		})
 		.toStrictEqual({
 			source: 'Updated',
 		});

--- a/packages/request-state/e2e/view-transitions.spec.ts
+++ b/packages/request-state/e2e/view-transitions.spec.ts
@@ -22,9 +22,9 @@ test('apply new state after view transition', async ({ page }) => {
 	const pageUrl = fixture.resolveUrl('/?name=Emily');
 
 	await page.goto(pageUrl);
-	expect(page.locator('#name')).toHaveText('Emily');
+	await expect(page.locator('#name')).toHaveText('Emily');
 
 	await page.locator('a').click();
 	await expect(page).toHaveURL(fixture.resolveUrl('/?name=John'));
-	expect(page.locator('#name')).toHaveText('John');
+	await expect(page.locator('#name')).toHaveText('John');
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,24 @@ importers:
         specifier: ^7.0.7
         version: 7.0.7(patch_hash=34ac88963a271f59948954a697fdf4850409d163faae6f020d77c206005cacc4)(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.4)(@vercel/functions@3.7.2)(db0@0.3.4)(ioredis@5.8.2)(jiti@2.6.1)(rollup@4.62.2)(terser@5.44.1)(yaml@2.9.0)
 
+  packages/git-redirect:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.4
+      astro:
+        specifier: ^7.0.7
+        version: 7.0.7(patch_hash=34ac88963a271f59948954a697fdf4850409d163faae6f020d77c206005cacc4)(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.4)(@vercel/functions@3.7.2)(db0@0.3.4)(ioredis@5.8.2)(jiti@2.6.1)(rollup@4.62.2)(terser@5.44.1)(yaml@2.9.0)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.19)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
+
   packages/inline-mod:
     dependencies:
       '@inox-tools/utils':


### PR DESCRIPTION
## Intent

Create `@inox-tools/git-redirect`, an Astro integration configured with path/prefix sources. Inspect each containing repository's HEAD rename history once, compose rename chains, and register redirects for `.astro`, `.md`, and `.mdx` using normalized prefixes, extension removal, and index collapsing. Resolve relative and absolute paths; keep only existing current targets; never shadow current routes or explicit or earlier redirects; handle file sources and reused paths. Include focused tests, package metadata, lockfile updates, labeling, and a changeset; commit, push, and open the PR.

## What Changed

- Add `@inox-tools/git-redirect`, an Astro integration that discovers page renames from Git history and generates redirects for configured file or directory sources.
- Compose rename chains, normalize route paths, preserve current routes and explicit redirects, support nested repositories and dynamic route bindings, and reject shallow history.
- Add package documentation, focused tests, release metadata, lockfile and labeler updates, plus more reliable asynchronous assertions in request-state end-to-end tests.

## Risk Assessment

🚨 High: The change can replace existing dynamic or nested-repository Astro routes despite its central precedence guarantee, so it should not merge without correction.

## Testing

Inspected the target change, built the package, ran its focused automated suite, then exercised a disposable Git-backed Astro project end to end: chained `.astro`, `.md`, and `.mdx` renames produced 301 responses to normalized, index-collapsed targets while current pages returned 200; the HTTP/build transcript was captured and the worktree was cleaned successfully.

<details>
<summary>Evidence: Astro end-to-end redirect transcript</summary>

<code>Git histories for .astro, .md, and .mdx routes were renamed through chains. Astro returned 301 Location headers from all historical URLs to `/docs/guide`, `/articles/releases`, or `/notes/release-notes`; each current target returned 200. SHA-256: 9cf0d361f7d2734d6946a49c2f891cf51878590fc1651460c2a4f90fb96ee477.</code>

```text
# `@inox-tools/git-redirect` Astro E2E evidence

Fixture: `/tmp/no-mistakes-evidence/01KXTVF48PQ71GZZQ90R32KK18/e2e`

## Git history and configured sources

`` `console
$ git log --oneline --reverse -- src/pages
4070969 add initial Astro Markdown and MDX routes
6b03f2e rename initial documentation announcement and notes
a764050 collapse documentation and Markdown routes into indexes
`` `

The commits create these rename histories:

- `.astro`: `docs/intro.astro` → `docs/getting-started.astro` → `docs/guide/index.astro`
- `.md`: `articles/announcement.md` → `articles/news.md` → `articles/releases/index.md`
- `.mdx`: `notes/changelog.mdx` → `notes/release-notes.mdx`

`astro.config.mjs` uses the built worktree package and these realistic page sources:

`` `js
gitRedirect([
  { path: 'src/pages/docs', prefix: 'docs//' },
  { path: 'src/pages/articles', prefix: 'articles/' },
  { path: 'src/pages/notes/release-notes.mdx', prefix: 'notes' },
])
`` `

The `docs//` prefix confirms prefix normalization; the final `guide/index.astro` and `releases/index.md` confirm index-route collapse.

## Build

`` `console
$ pnpm --filter @inox-tools/git-redirect build
ESM ⚡️ Build success
DTS ⚡️ Build success

$ pnpm build
[build] output: "static"
 generating static routes
  ├─ /articles/announcement/index.html
  ├─ /articles/news/index.html
  ├─ /articles/releases/index.html
  ├─ /docs/getting-started/index.html
  ├─ /docs/guide/index.html
  ├─ /docs/intro/index.html
  ├─ /notes/changelog/index.html
  ├─ /notes/release-notes/index.html
[build] Complete!
`` `

## Direct Astro HTTP evidence

The development server was started with:

`` `console
$ pnpm exec astro dev --host 127.0.0.1 --port 4322
astro v7.0.7 ready
Local http://127.0.0.1:4322/
`` `

Each old URL returned a permanent redirect from Astro (headers shown):

`` `console
$ curl -sS -D - -o /dev/null http://127.0.0.1:4322/docs/intro/
HTTP/1.1 301 Moved Permanently
location: /docs/guide

$ curl -sS -D - -o /dev/null http://127.0.0.1:4322/docs/getting-started/
HTTP/1.1 301 Moved Permanently
location: /docs/guide

$ curl -sS -D - -o /dev/null http://127.0.0.1:4322/articles/announcement/
HTTP/1.1 301 Moved Permanently
location: /articles/releases

$ curl -sS -D - -o /dev/null http://127.0.0.1:4322/articles/news/
HTTP/1.1 301 Moved Permanently
location: /articles/releases

$ curl -sS -D - -o /dev/null http://127.0.0.1:4322/notes/changelog/
HTTP/1.1 301 Moved Permanently
location: /notes/release-notes
`` `

Current targets remained live:

`` `console
$ curl -sS -D - -o /dev/null http://127.0.0.1:4322/docs/guide/
HTTP/1.1 200 OK
content-type: text/html

$ curl -sS -i http://127.0.0.1:4322/articles/releases/
HTTP/1.1 200 OK
content-type: text/html
...
<h1 id="markdown-current-page">Markdown current page</h1>

$ curl -sS -D - -o /dev/null http://127.0.0.1:4322/notes/release-notes/
HTTP/1.1 200 OK
content-type: text/html

$ curl -sS http://127.0.0.1:4322/notes/release-notes/
...
<h1 id="mdx-current-page">MDX current page</h1>
`` `

The server was stopped after capture.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 5 issues (2 errors, 3 warnings)</summary>

- 🚨 `packages/git-redirect/src/index.ts:76` - Existing-route detection only scans configured source trees, despite the public contract that every existing Astro route takes precedence. A source such as `content/guides` with prefix `/guides` can generate `/guides/old` while an unconfigured `src/pages/guides/old.astro` or endpoint already serves that URL, causing a redirect collision. Use Astro&#39;s complete resolved route set rather than deriving routes only from configured sources.
- 🚨 `packages/git-redirect/README.md:19` - The primary setup example imports `defineConfig` from `astro`, but the supported Astro 7 package exposes it through `astro/config`. Copying this example fails while loading `astro.config.mjs`; match the correct import already used by the documentation page.
- ⚠️ `packages/git-redirect/src/index.ts:348` - The pages traversal excludes underscore-prefixed entries but includes arbitrary dot-prefixed entries. Astro 7 excludes dot-prefixed page files and directories except `.well-known`, so renaming `old.md` to `.hidden.md` generates `/old -&gt; /.hidden` even though the destination route does not exist. Mirror Astro&#39;s dot-entry rule.
- ⚠️ `packages/git-redirect/src/index.ts:354` - Directory traversal only accepts Dirents reported directly as files or directories, so symbolic links fall through. Astro follows filesystem symlinks when discovering routes; consequently, a tracked page symlink renamed from `old.md` to `new.md` can serve `/new` while this integration generates no `/old` redirect. Follow page symlinks consistently, with repository-boundary and directory-cycle protection.
- ⚠️ `packages/git-redirect/src/index.ts:208` - `git log --find-renames` inherits Git&#39;s `diff.renameLimit`. Large commits can therefore skip exhaustive inexact rename detection, report edited renames as additions/deletions, and still exit successfully; stderr is discarded on success, so redirects silently disappear. Request unlimited detection with `-l0` or detect the warning and fail with actionable guidance.

🔧 Fix: Harden Git redirect route discovery and examples
5 issues (2 errors, 3 warnings) still open:
- 🚨 `packages/git-redirect/src/index.ts:114` - Collision checks use exact route strings rather than Astro routing semantics. A generated static `/docs/about` redirect shadows an existing `/docs/[slug]` page, and `/docs/[id]` can conflict with an existing route or explicit redirect keyed as `/docs/[slug]`; explicit keys such as `/old/` also bypass the `/old` check. Canonicalize and compare route patterns for overlap—including static, dynamic, spread, and slash-normalized forms—before generating redirects.
- 🚨 `packages/git-redirect/src/index.ts:412` - Global Astro route discovery reuses source traversal that skips every child directory containing `.git`. A live `src/pages/docs/legacy.astro` inside a nested repository is therefore absent from `currentRoutes`, allowing another source to install `/docs/legacy` and replace that page. Keep nested repositories excluded from rename-history sources, but include their files when inventorying live Astro routes.
- ⚠️ `packages/git-redirect/src/index.ts:94` - Traversal follows directory symlinks but returns lexical paths for Git lookup. If `src/pages/docs` links to tracked `content/docs`, Git records `content/docs/old.md -&gt; content/docs/current.md` while `currentPaths` contains `src/pages/docs/current.md`, so no redirect is found. Preserve separate canonical repository paths for history and lexical paths for route generation; this also avoids rejecting repository roots accessed through symlink aliases.
- ⚠️ `packages/git-redirect/src/index.ts:8` - The shared extension set makes `.html`, Markdown aliases, `.js`, and `.ts` eligible for generated redirects, while the public contract states that only `.astro`, `.md`, and `.mdx` renames generate redirects. This can unexpectedly redirect renamed API endpoints. Decide whether the expanded behavior is intentional; otherwise separate broad live-route discovery extensions from the three rename-eligible extensions.
- ⚠️ `packages/git-redirect/src/index.ts:297` - Each source scans the fully materialized repository-wide history and clones its entire active-path map for every commit. Cost grows roughly with sources × commits × current paths after the Git output has already been buffered and parsed into additional copies, creating substantial startup and memory risk in large monorepos. Resolve all sources for a repository in one streaming/indexed pass and update only paths touched by each commit.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm run build` in `packages/git-redirect`</code>
- <code>`pnpm run test` in `packages/git-redirect`</code>
- <code>`pnpm --filter @inox-tools/git-redirect build` for the disposable Astro fixture</code>
- <code>`pnpm build` in `/tmp/no-mistakes-evidence/01KXTVF48PQ71GZZQ90R32KK18/e2e`</code>
- <code>`pnpm exec astro dev --host 127.0.0.1 --port 4322` in the disposable fixture</code>
- <code>`curl -sS -D - -o /dev/null http://127.0.0.1:4322/{docs/intro,docs/getting-started,articles/announcement,articles/news,notes/changelog}/` to verify generated redirects</code>
- <code>HTTP requests to `/docs/guide/`, `/articles/releases/`, and `/notes/release-notes/` to verify current targets remained live</code>
- <code>`git status --short` after removing transient `packages/git-redirect/dist` output</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
