### PR TITLE
feat(every-astro): add interactive Astro regression bisect CLI

### DIFF
--- a/.changeset/brave-stars-bisect.md
+++ b/.changeset/brave-stars-bisect.md
@@ -1,0 +1,5 @@
+---
+'@inox-tools/every-astro': minor
+---
+
+Add the `every-astro` CLI for interactively bisecting Astro regressions against a local project.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,36 @@ jobs:
       - name: Test
         run: pnpm run test
 
+
+  every-astro-windows:
+    name: Every Astro Windows
+    runs-on: windows-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4.2.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        shell: pwsh
+        run: pnpm install
+
+      - name: Build every-astro
+        shell: pwsh
+        run: pnpm --filter @inox-tools/every-astro build
+
+      - name: Test every-astro
+        shell: pwsh
+        run: pnpm --filter @inox-tools/every-astro test
   test-e2e:
     name: E2E test
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
 # INOX-TOOLS
 
-**Generated:** 2026-02-09 | **Commit:** 771ef53 | **Branch:** main
+**Generated:** 2026-07-18 | **Commit:** 4790d7e | **Branch:** every-astro
 
 ## OVERVIEW
 
-pnpm monorepo of 17 `@inox-tools/*` packages — Astro integrations, Vite plugins, and utilities. Built with Turbo, tsup, TypeScript strict mode. Author: Luiz Ferraz (Fryuni).
+pnpm monorepo of 18 `@inox-tools/*` packages — Astro integrations, Vite plugins, CLIs, and utilities. Built with Turbo, tsup, TypeScript strict mode. Author: Luiz Ferraz (Fryuni).
 
 ## STRUCTURE
 
 ```
 inox-tools/
-├── packages/           # 17 @inox-tools/* packages (the product)
+├── packages/           # 18 @inox-tools/* packages (the product)
 │   ├── utils/          # Foundational: Lazy, Once, unist visitor (16+ consumers)
 │   ├── inline-mod/     # Most complex: closure serialization via V8 introspection
 │   ├── modular-station/# Integration hook system (withApi, onHook)
@@ -28,7 +28,8 @@ inox-tools/
 │   ├── star-warp/      # Pagefind search integration
 │   ├── sitemap-ext/    # Sitemap extension (entry at root index.ts, not src/)
 │   ├── velox-luna/     # CLI tool for Lunaria i18n
-│   └── dev-timings/    # Dev timing instrumentation
+│   ├── dev-timings/    # Dev timing instrumentation
+│   └── every-astro/    # Interactive Astro regression bisect CLI
 ├── examples/           # 11 demo Astro projects
 ├── docs/               # Starlight documentation site
 ├── turbo/              # Turbo generators for scaffolding new packages
@@ -44,6 +45,7 @@ inox-tools/
 | Add new Vite plugin  | `turbo gen` → `turbo/generators/vite-plugin/` | Separate template set                                               |
 | Shared utilities     | `packages/utils/src/`                         | Import as `@inox-tools/utils/lazy`, `@inox-tools/utils/values` etc. |
 | Test utilities       | `packages/astro-tests/`                       | `loadFixture()`, `testAdapter()`                                    |
+| Bisect Astro bugs    | `packages/every-astro/`                       | Builds and links Astro revisions into a local project               |
 | Virtual module types | `packages/*/virtual.d.ts`                     | All use `@it-astro:*` namespace                                     |
 | Package deps catalog | `pnpm-workspace.yaml` `catalog:` section      | Single source of truth for versions                                 |
 | Astro patch          | `patches/astro.patch`                         | Applied automatically at install                                    |
@@ -56,6 +58,7 @@ T2 Infra:       modular-station → utils, runtime-logger → modular-station
 T3 Features:    request-state, portal-gun, cut-short, server-islands → utils
 T4 Composed:    request-nanostores → request-state, content-utils → modular-station
 T5 Wrappers:    sitemap-ext → route-config
+Standalone:     every-astro (external dependencies only)
 ```
 
 ## CONVENTIONS
@@ -77,8 +80,8 @@ T5 Wrappers:    sitemap-ext → route-config
 
 - Entry: `src/index.ts` (exception: `sitemap-ext` uses root `index.ts`)
 - Build: `tsup` → `dist/` for every package
-- Exports: Conditional `types` + `default` in package.json `exports` field
-- Files shipped: `dist`, `src`, `virtual.d.ts`
+- Exports: Libraries use conditional `types` + `default`; `every-astro` exposes CLI bins
+- Files shipped: Package-specific `files` entries generally include `dist` and `src`
 
 ### Integration Pattern (ALL Astro integrations follow this)
 
@@ -137,7 +140,7 @@ turbo gen                       # Scaffold new package from templates
 - Nix flake available for dev environment (`flake.nix`)
 - `inline-mod/src/closure/entry.test.ts` is colocated with source (only exception to test separation)
 - `star-warp/routes/*` exports point to source files directly (not dist)
-- Node 22+ recommended (CI matrix: 20, 22)
+- Node 22+ recommended (CI matrix: 20, 22); `every-astro` requires Node 22.12+
 
 ## Brain — Agent Memory
 

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -109,6 +109,10 @@ export default defineConfig({
 					collapsed: false,
 					items: [
 						{
+							label: 'Every Astro',
+							link: '/every-astro',
+						},
+						{
 							label: 'Astro Integration Template',
 							link: 'https://astro-integration-template.netlify.app',
 						},

--- a/docs/src/content/docs/every-astro.mdx
+++ b/docs/src/content/docs/every-astro.mdx
@@ -15,6 +15,7 @@ Before running Every Astro, make sure the project has:
 - Node.js 22.12.0 or newer, Git, and the project's package manager available on your `PATH`.
 - Astro and the project's dependencies already installed.
 - A `dev` script that starts the project and keeps running while you test it.
+- On Windows, a direct foreground Astro dev command such as `"dev": "astro dev"`; wrapper, background, and shell-composed scripts are rejected.
 - A lockfile for pnpm, npm, Yarn, or Bun.
 
 Both Yarn Classic and Yarn Berry are supported, including Plug'n'Play projects. In a monorepo, run the

--- a/docs/src/content/docs/every-astro.mdx
+++ b/docs/src/content/docs/every-astro.mdx
@@ -15,7 +15,6 @@ Before running Every Astro, make sure the project has:
 - Node.js 22.12.0 or newer, Git, and the project's package manager available on your `PATH`.
 - Astro and the project's dependencies already installed.
 - A `dev` script that starts the project and keeps running while you test it.
-- On Windows, a direct foreground Astro dev command such as `"dev": "astro dev"`; wrapper, background, and shell-composed scripts are rejected.
 - A lockfile for pnpm, npm, Yarn, or Bun.
 
 Both Yarn Classic and Yarn Berry are supported, including Plug'n'Play projects. In a monorepo, run the

--- a/docs/src/content/docs/every-astro.mdx
+++ b/docs/src/content/docs/every-astro.mdx
@@ -32,8 +32,9 @@ npx @inox-tools/every-astro
 The CLI detects the installed Astro major and then:
 
 1. Clones the complete Astro repository into a temporary directory.
-2. Builds and tests the latest repository revision.
-3. Builds and tests the first release of the installed major, displayed as `v<major>.0.0`.
+2. Builds and tests the latest revision in the installed major. When clone HEAD's Astro package has that
+   major, this is HEAD; otherwise it is the highest stable release tag in the installed major.
+3. Builds and tests the inclusive first release of the installed major, displayed as `v<major>.0.0`.
 4. If the two revisions bracket the regression, runs `git bisect` and tests revisions until it finds the
    first bad commit.
 
@@ -46,9 +47,10 @@ For each tested revision, Every Astro starts your project's `dev` script and dis
 Wait for the development server to be ready, reproduce the bug, and answer `y` or `n`. Use the same
 test every time: inconsistent answers can lead `git bisect` to the wrong commit.
 
-Every Astro reports early when the bug is already fixed in the latest repository revision or was
-already present in the first release of the installed major. Otherwise, it reports the exact first bad
-commit. It does not bisect across Astro major versions.
+Every Astro reports early when the bug is already fixed in the latest revision in the installed major or
+already present in the inclusive first release. In the latter case, this only establishes that the
+introduction is outside the selected major range. Otherwise, it reports the exact first bad commit. It
+does not bisect across Astro major versions.
 
 :::note[Allow time and disk space]
 Every tested revision requires an install and a full Astro monorepo build. The complete repository is
@@ -84,9 +86,9 @@ reporting a successful result. Inspect those errors and your dependency state be
 
 The CLI ends with one of three messages:
 
-- **Already fixed:** the bug is absent from the latest Astro repository revision.
-- **Predates the major:** the bug is present in `v<major>.0.0`, so an earlier boundary is outside this
-  run's scope.
+- **Already fixed:** the bug is absent from the latest revision in the installed major.
+- **Outside the selected range:** the bug is already present in `v<major>.0.0`; this only establishes
+  that its introduction is outside the selected major range.
 - **First bad commit:** the reported 40-character commit is the first Astro revision where your answers
   indicated that the bug is present.
 

--- a/docs/src/content/docs/every-astro.mdx
+++ b/docs/src/content/docs/every-astro.mdx
@@ -48,9 +48,9 @@ Wait for the development server to be ready, reproduce the bug, and answer `y` o
 test every time: inconsistent answers can lead `git bisect` to the wrong commit.
 
 Every Astro reports early when the bug is already fixed in the latest revision in the installed major or
-already present in the inclusive first release. In the latter case, this only establishes that the
-introduction is outside the selected major range. Otherwise, it reports the exact first bad commit. It
-does not bisect across Astro major versions.
+already present in the inclusive first release. In the latter case, its introduction is at or before the
+first-release boundary; earlier history is not bisected. Otherwise, it reports the exact first bad commit.
+It does not bisect across Astro major versions.
 
 :::note[Allow time and disk space]
 Every tested revision requires an install and a full Astro monorepo build. The complete repository is
@@ -87,8 +87,8 @@ reporting a successful result. Inspect those errors and your dependency state be
 The CLI ends with one of three messages:
 
 - **Already fixed:** the bug is absent from the latest revision in the installed major.
-- **Outside the selected range:** the bug is already present in `v<major>.0.0`; this only establishes
-  that its introduction is outside the selected major range.
+- **At or before the first-release boundary:** the bug is already present in `v<major>.0.0`; earlier
+  history is not bisected.
 - **First bad commit:** the reported 40-character commit is the first Astro revision where your answers
   indicated that the bug is present.
 

--- a/docs/src/content/docs/every-astro.mdx
+++ b/docs/src/content/docs/every-astro.mdx
@@ -1,0 +1,98 @@
+---
+title: Every Astro
+description: Find the Astro commit that introduced a regression in your project
+packageName: '@inox-tools/every-astro'
+---
+
+Every Astro is an interactive CLI that finds the Astro commit that introduced a bug you can reproduce
+in your project. It tests your project against revisions from the Astro repository and uses
+[`git bisect`](https://git-scm.com/docs/git-bisect) to identify the first bad commit.
+
+## Requirements
+
+Before running Every Astro, make sure the project has:
+
+- Node.js 22.12.0 or newer, Git, and the project's package manager available on your `PATH`.
+- Astro and the project's dependencies already installed.
+- A `dev` script that starts the project and keeps running while you test it.
+- A lockfile for pnpm, npm, Yarn, or Bun.
+
+Both Yarn Classic and Yarn Berry are supported, including Plug'n'Play projects. In a monorepo, run the
+command from the directory of the Astro project you want to test. Every Astro searches upward from that
+directory for package manager configuration and a lockfile.
+
+## Run the bisect
+
+From your Astro project's directory, run:
+
+```sh
+npx @inox-tools/every-astro
+```
+
+The CLI detects the installed Astro major and then:
+
+1. Clones the complete Astro repository into a temporary directory.
+2. Builds and tests the latest repository revision.
+3. Builds and tests the first release of the installed major, displayed as `v<major>.0.0`.
+4. If the two revisions bracket the regression, runs `git bisect` and tests revisions until it finds the
+   first bad commit.
+
+For each tested revision, Every Astro starts your project's `dev` script and displays a prompt like:
+
+```text
+<revision>: is the bug present? [y/n]
+```
+
+Wait for the development server to be ready, reproduce the bug, and answer `y` or `n`. Use the same
+test every time: inconsistent answers can lead `git bisect` to the wrong commit.
+
+Every Astro reports early when the bug is already fixed in the latest repository revision or was
+already present in the first release of the installed major. Otherwise, it reports the exact first bad
+commit. It does not bisect across Astro major versions.
+
+:::note[Allow time and disk space]
+Every tested revision requires an install and a full Astro monorepo build. The complete repository is
+cloned rather than shallow-cloned, so the process can take significant time and temporary disk space.
+:::
+
+## Package manager detection
+
+Every Astro supports pnpm, npm, Yarn Classic, Yarn Berry, Yarn Plug'n'Play, and Bun. Starting in the
+current directory and walking upward, it uses a recognized `packageManager` field or a conventional
+lockfile. A `packageManager` field at a given directory takes precedence over a lockfile in that same
+directory. Recognized lockfiles are `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`,
+`package-lock.json`, and `npm-shrinkwrap.json`.
+
+The lockfile is required so Every Astro can restore the exact dependency tree after substituting Astro
+packages. For each revision, it discovers the public `astro` and `@astrojs/*` workspace packages that
+exist in that checkout and substitutes the ones used by your project's dependency graph.
+
+## Cleanup and interruption
+
+Every Astro cleans up after a successful result, an error, `Ctrl+C`, or a termination signal. Cleanup:
+
+- Stops the development server and its child processes.
+- Restores package manifests and the original lockfile byte-for-byte.
+- Reinstalls the locked dependency tree and restores original dependency symlinks.
+- Unlinks packages from the tested Astro revision.
+- Resets the temporary repository's bisect state and removes the temporary clone.
+
+If cleanup fails during a normal run, the CLI exits with the collected cleanup errors instead of
+reporting a successful result. Inspect those errors and your dependency state before continuing work.
+
+## Interpreting the result
+
+The CLI ends with one of three messages:
+
+- **Already fixed:** the bug is absent from the latest Astro repository revision.
+- **Predates the major:** the bug is present in `v<major>.0.0`, so an earlier boundary is outside this
+  run's scope.
+- **First bad commit:** the reported 40-character commit is the first Astro revision where your answers
+  indicated that the bug is present.
+
+The result is only as reliable as the reproduction. If the behavior depends on timing, external state,
+or an unrelated package version, stabilize those conditions before running the CLI.
+
+## License
+
+Every Astro is available under the MIT license.

--- a/packages/every-astro/README.md
+++ b/packages/every-astro/README.md
@@ -7,9 +7,11 @@
 Find the Astro commit that introduced a regression in your project.
 
 Every Astro clones the Astro repository, builds selected revisions, runs your project's development
-server against each one, and asks whether the bug is present. It checks the latest repository revision
-and the first release of your installed Astro major before starting `git bisect`, so it can also tell you
-when the bug is already fixed or predates that major.
+server against each one, and asks whether the bug is present. It checks the latest revision in the
+installed Astro major and the inclusive first release of that major before starting `git bisect`. When
+clone HEAD's Astro package has the installed major, HEAD is the latest revision; otherwise Every Astro
+uses the highest stable release tag in that major. This can show that the bug is already fixed or already
+present at the selected range's first release.
 
 ## Requirements
 
@@ -37,8 +39,8 @@ reliable result.
 
 The CLI only searches within the installed Astro major. It reports one of these outcomes:
 
-- The bug is fixed in the latest Astro repository revision.
-- The bug was already present in `v<major>.0.0` and therefore predates that major.
+- The bug is fixed in the latest revision in the installed major.
+- The bug is already present in `v<major>.0.0`; its introduction is outside the selected major range.
 - The exact first bad Astro commit.
 
 Every Astro uses the package manager declared in the nearest `package.json`, or detects it from the

--- a/packages/every-astro/README.md
+++ b/packages/every-astro/README.md
@@ -19,12 +19,14 @@ present at the selected range's first release.
 - Git and the project's package manager available on your `PATH`
 - An Astro project with dependencies already installed
 - A `dev` script that starts the project and keeps running
-- On Windows, a direct foreground Astro dev command such as `"dev": "astro dev"`; wrapper, background, and shell-composed scripts are rejected.
 - A pnpm, npm, Yarn, or Bun lockfile
 
 Both Yarn Classic and Yarn Berry, including Plug'n'Play projects, are supported. In a monorepo, run the
 command from the Astro project's directory; Every Astro searches parent directories for the package
 manager configuration and lockfile.
+
+On Windows, Every Astro launches each command in a kill-on-close Job Object. Its supervisor integration test
+runs only on Windows because non-Windows environments cannot execute the Win32 API path.
 
 ## Usage
 

--- a/packages/every-astro/README.md
+++ b/packages/every-astro/README.md
@@ -19,6 +19,7 @@ present at the selected range's first release.
 - Git and the project's package manager available on your `PATH`
 - An Astro project with dependencies already installed
 - A `dev` script that starts the project and keeps running
+- On Windows, a direct foreground Astro dev command such as `"dev": "astro dev"`; wrapper, background, and shell-composed scripts are rejected.
 - A pnpm, npm, Yarn, or Bun lockfile
 
 Both Yarn Classic and Yarn Berry, including Plug'n'Play projects, are supported. In a monorepo, run the

--- a/packages/every-astro/README.md
+++ b/packages/every-astro/README.md
@@ -43,7 +43,7 @@ reliable result.
 The CLI only searches within the installed Astro major. It reports one of these outcomes:
 
 - The bug is fixed in the latest revision in the installed major.
-- The bug is already present in `v<major>.0.0`; its introduction is outside the selected major range.
+- The bug is already present in `v<major>.0.0`; its introduction is at or before the first-release boundary, and earlier history is not bisected.
 - The exact first bad Astro commit.
 
 Every Astro uses the package manager declared in the nearest `package.json`, or detects it from the

--- a/packages/every-astro/README.md
+++ b/packages/every-astro/README.md
@@ -1,0 +1,59 @@
+<p align="center">
+    <img alt="InoxTools" width="350px" src="https://github.com/Fryuni/inox-tools/blob/main/assets/shield.png?raw=true"/>
+</p>
+
+# Every Astro
+
+Find the Astro commit that introduced a regression in your project.
+
+Every Astro clones the Astro repository, builds selected revisions, runs your project's development
+server against each one, and asks whether the bug is present. It checks the latest repository revision
+and the first release of your installed Astro major before starting `git bisect`, so it can also tell you
+when the bug is already fixed or predates that major.
+
+## Requirements
+
+- Node.js 22.12.0 or newer
+- Git and the project's package manager available on your `PATH`
+- An Astro project with dependencies already installed
+- A `dev` script that starts the project and keeps running
+- A pnpm, npm, Yarn, or Bun lockfile
+
+Both Yarn Classic and Yarn Berry, including Plug'n'Play projects, are supported. In a monorepo, run the
+command from the Astro project's directory; Every Astro searches parent directories for the package
+manager configuration and lockfile.
+
+## Usage
+
+Run the CLI from the Astro project where you can reproduce the bug:
+
+```sh
+npx @inox-tools/every-astro
+```
+
+For each revision, wait for the development server to be ready, reproduce the bug, and answer the
+prompt with `y` or `n`. The answer must describe the same behavior every time for `git bisect` to find a
+reliable result.
+
+The CLI only searches within the installed Astro major. It reports one of these outcomes:
+
+- The bug is fixed in the latest Astro repository revision.
+- The bug was already present in `v<major>.0.0` and therefore predates that major.
+- The exact first bad Astro commit.
+
+Every Astro uses the package manager declared in the nearest `package.json`, or detects it from the
+nearest `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, `package-lock.json`, or
+`npm-shrinkwrap.json`. It builds every tested Astro revision and substitutes all `astro` and
+`@astrojs/*` packages from that revision that are used by the project, so a run can take significant
+time and disk space.
+
+## Cleanup
+
+On success, failure, `SIGINT`, or `SIGTERM`, Every Astro stops the development server, restores the
+project manifests, lockfile, installed dependencies, and original dependency links, resets the cloned
+repository's bisect state, and removes the temporary clone. If cleanup cannot complete, the command
+fails instead of reporting a successful result. Cleanup also runs when the command is interrupted.
+
+## License
+
+Every Astro is available under the MIT license.

--- a/packages/every-astro/package.json
+++ b/packages/every-astro/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@inox-tools/every-astro",
+  "version": "0.0.0",
+  "description": "Bisect the Astro repository against your project's dev server to find the exact commit that introduced a bug",
+  "keywords": [
+    "astro",
+    "bisect",
+    "cli",
+    "debugging"
+  ],
+  "repository": {
+    "url": "https://github.com/Fryuni/inox-tools"
+  },
+  "license": "MIT",
+  "author": "Luiz Ferraz <luiz@lferraz.com>",
+  "type": "module",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "bin": {
+    "@inox-tools/every-astro": "./dist/index.js",
+    "every-astro": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "prepublish": "pnpm run build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "corepack": "catalog:",
+    "cross-spawn": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/every-astro/src/index.ts
+++ b/packages/every-astro/src/index.ts
@@ -1,0 +1,44 @@
+import { createRuntimeDependencies } from './runtime.js';
+import { runEveryAstro } from './workflow.js';
+
+let interruptedBy: 'SIGINT' | 'SIGTERM' | undefined;
+
+async function main(): Promise<void> {
+	const abortController = new AbortController();
+
+	const onSigint = () => {
+		interruptedBy ??= 'SIGINT';
+		abortController.abort();
+	};
+	const onSigterm = () => {
+		interruptedBy ??= 'SIGTERM';
+		abortController.abort();
+	};
+
+	process.on('SIGINT', onSigint);
+	process.on('SIGTERM', onSigterm);
+
+	try {
+		const dependencies = await createRuntimeDependencies(process.cwd(), abortController.signal);
+
+		await runEveryAstro(dependencies);
+	} finally {
+		process.off('SIGINT', onSigint);
+		process.off('SIGTERM', onSigterm);
+	}
+}
+
+process.setSourceMapsEnabled(true);
+
+main().catch((error: unknown) => {
+	if (interruptedBy !== undefined) {
+		// Interrupted by the user; cleanup already ran through the abort signal.
+		process.exitCode = interruptedBy === 'SIGINT' ? 130 : 143;
+		return;
+	}
+
+	// eslint-disable-next-line no-console
+	console.error(error);
+
+	process.exitCode = 1;
+});

--- a/packages/every-astro/src/index.ts
+++ b/packages/every-astro/src/index.ts
@@ -1,5 +1,5 @@
 import { createRuntimeDependencies } from './runtime.js';
-import { runEveryAstro } from './workflow.js';
+import { isPlainAbortError, runEveryAstro } from './workflow.js';
 
 let interruptedBy: 'SIGINT' | 'SIGTERM' | undefined;
 
@@ -31,7 +31,7 @@ async function main(): Promise<void> {
 process.setSourceMapsEnabled(true);
 
 main().catch((error: unknown) => {
-	if (interruptedBy !== undefined) {
+	if (interruptedBy !== undefined && isPlainAbortError(error)) {
 		// Interrupted by the user; cleanup already ran through the abort signal.
 		process.exitCode = interruptedBy === 'SIGINT' ? 130 : 143;
 		return;
@@ -40,5 +40,5 @@ main().catch((error: unknown) => {
 	// eslint-disable-next-line no-console
 	console.error(error);
 
-	process.exitCode = 1;
+	process.exitCode = interruptedBy === undefined ? 1 : interruptedBy === 'SIGINT' ? 130 : 143;
 });

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -270,7 +270,10 @@ async function readPnpManifest(
 	};
 	if (signal) signal.addEventListener('abort', abort, { once: true });
 
-	let manifest: PackageManifest | undefined;
+	let output = '';
+	let errors = '';
+	let streamError: unknown;
+	let exitCode: number | null | undefined;
 	let primaryError: unknown;
 	try {
 		temporaryRoot =
@@ -297,33 +300,31 @@ async function readPnpManifest(
 			}
 		);
 		child = reader;
-		let output = '';
-		let errors = '';
 		reader.stdout?.on('data', (chunk: Buffer) => {
 			output += chunk;
 		});
+		reader.stdout?.once('error', (error) => {
+			streamError ??= error;
+		});
 		reader.stderr?.on('data', (chunk: Buffer) => {
 			errors += chunk;
+		});
+		reader.stderr?.once('error', (error) => {
+			streamError ??= error;
 		});
 		closed = new Promise<void>((resolveClose) => {
 			reader.once('close', () => resolveClose());
 		});
 		const completion = new Promise<number | null>((resolveExit, rejectExit) => {
 			reader.once('error', rejectExit);
-			reader.once('close', resolveExit);
+			reader.once('exit', resolveExit);
 		});
 		if (signal?.aborted) abort();
-		const exitCode = await Promise.race([completion, aborted]);
+		exitCode = await Promise.race([completion, aborted]);
 		if (signal?.aborted) {
 			await abortCompletion;
 			throw abortError(signal);
 		}
-		if (exitCode !== 0) {
-			throw new Error(
-				`Could not read PnP manifest ${manifestPath} with Corepack Yarn (exit code ${exitCode}): ${errors}`
-			);
-		}
-		manifest = JSON.parse(output) as PackageManifest;
 	} catch (error) {
 		primaryError = error;
 	} finally {
@@ -357,8 +358,15 @@ async function readPnpManifest(
 		}
 	}
 	if (primaryError !== undefined) throw primaryError;
-	pnpManifests.set(manifestPath, manifest!);
-	return manifest!;
+	if (streamError) throw streamError;
+	if (exitCode !== 0) {
+		throw new Error(
+			`Could not read PnP manifest ${manifestPath} with Corepack Yarn (exit code ${exitCode}): ${errors}`
+		);
+	}
+	const manifest = JSON.parse(output) as PackageManifest;
+	pnpManifests.set(manifestPath, manifest);
+	return manifest;
 }
 
 async function manifestAt(path: string, packageName: string): Promise<string | undefined> {

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -214,6 +214,30 @@ function loadPnpApi(pnpPath: string | undefined): PnpApi | undefined {
 	return pnpapi;
 }
 
+async function spawnSupervisedCommand(
+	temporaryRoot: string,
+	file: string,
+	args: string[],
+	options: NonNullable<Parameters<typeof spawn>[2]>
+): Promise<ChildProcess> {
+	if (process.platform !== 'win32') return spawn(file, args, options);
+
+	const controlFile = join(temporaryRoot, `command-${randomUUID()}.json`);
+	await writeFile(controlFile, JSON.stringify({ file, args }));
+	let child: ChildProcess;
+	try {
+		const [supervisor, ...supervisorArgs] = windowsJobSupervisorCommand(controlFile);
+		child = spawn(supervisor, supervisorArgs, options);
+	} catch (error) {
+		await rm(controlFile, { force: true });
+		throw error;
+	}
+	const cleanControlFile = () => void rm(controlFile, { force: true }).catch(() => undefined);
+	child.once('error', cleanControlFile);
+	child.once('close', cleanControlFile);
+	return child;
+}
+
 async function readPnpManifest(
 	pnpPath: string,
 	manifestPath: string,
@@ -223,23 +247,34 @@ async function readPnpManifest(
 	if (cached) return cached;
 	if (signal?.aborted) throw abortError(signal);
 
-	const child = spawn(
-		process.execPath,
-		[
-			corepackCli,
-			'yarn',
-			'node',
-			'-e',
-			"process.stdout.write(require('node:fs').readFileSync(process.argv[1], 'utf8'))",
-			manifestPath,
-		],
-		{
-			cwd: dirname(pnpPath),
-			detached: process.platform !== 'win32',
-			env: isolatedBootstrapEnvironment(),
-			stdio: ['ignore', 'pipe', 'pipe'],
-		}
-	);
+	const temporaryRoot =
+		process.platform === 'win32'
+			? await mkdtemp(join(tmpdir(), 'every-astro-pnp-reader-'))
+			: undefined;
+	let child: ChildProcess;
+	try {
+		child = await spawnSupervisedCommand(
+			temporaryRoot ?? '',
+			process.execPath,
+			[
+				corepackCli,
+				'yarn',
+				'node',
+				'-e',
+				"process.stdout.write(require('node:fs').readFileSync(process.argv[1], 'utf8'))",
+				manifestPath,
+			],
+			{
+				cwd: dirname(pnpPath),
+				detached: process.platform !== 'win32',
+				env: isolatedBootstrapEnvironment(),
+				stdio: ['ignore', 'pipe', 'pipe'],
+			}
+		);
+	} catch (error) {
+		if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true });
+		throw error;
+	}
 	let output = '';
 	let errors = '';
 	child.stdout?.on('data', (chunk: Buffer) => {
@@ -271,6 +306,7 @@ async function readPnpManifest(
 		);
 	};
 	if (signal) signal.addEventListener('abort', abort, { once: true });
+	let primaryError: unknown;
 	try {
 		const exitCode = await Promise.race([completion, aborted]);
 		if (signal?.aborted) {
@@ -282,12 +318,28 @@ async function readPnpManifest(
 				`Could not read PnP manifest ${manifestPath} with Corepack Yarn (exit code ${exitCode}): ${errors}`
 			);
 		}
+		const manifest = JSON.parse(output) as PackageManifest;
+		pnpManifests.set(manifestPath, manifest);
+		return manifest;
+	} catch (error) {
+		primaryError = error;
+		throw error;
 	} finally {
 		signal?.removeEventListener('abort', abort);
+		let cleanupError: unknown;
+		try {
+			await terminateChildProcess(child);
+			await closed;
+		} catch (error) {
+			cleanupError = error;
+		}
+		try {
+			if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true });
+		} catch (error) {
+			cleanupError ??= error;
+		}
+		if (cleanupError && primaryError === undefined) throw cleanupError;
 	}
-	const manifest = JSON.parse(output) as PackageManifest;
-	pnpManifests.set(manifestPath, manifest);
-	return manifest;
 }
 
 async function manifestAt(path: string, packageName: string): Promise<string | undefined> {
@@ -987,30 +1039,7 @@ export class RuntimeSession implements BisectSession {
 	): Promise<ChildProcess> {
 		return this.commandSpawner
 			? this.commandSpawner(file, args, options)
-			: this.spawnCommand(file, args, options);
-	}
-
-	private async spawnCommand(
-		file: string,
-		args: string[],
-		options: NonNullable<Parameters<typeof spawn>[2]>
-	): Promise<ChildProcess> {
-		if (process.platform !== 'win32') return spawn(file, args, options);
-
-		const controlFile = join(this.temporaryRoot, `command-${randomUUID()}.json`);
-		await writeFile(controlFile, JSON.stringify({ file, args }));
-		let child: ChildProcess;
-		try {
-			const [supervisor, ...supervisorArgs] = windowsJobSupervisorCommand(controlFile);
-			child = spawn(supervisor, supervisorArgs, options);
-		} catch (error) {
-			await rm(controlFile, { force: true });
-			throw error;
-		}
-		const cleanControlFile = () => void rm(controlFile, { force: true }).catch(() => undefined);
-		child.once('error', cleanControlFile);
-		child.once('close', cleanControlFile);
-		return child;
+			: spawnSupervisedCommand(this.temporaryRoot, file, args, options);
 	}
 
 	public async execute(

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -112,6 +112,8 @@ export const developmentServerStdio: ['ignore', 'inherit', 'inherit'] = [
 ];
 
 async function readManifest(path: string): Promise<PackageManifest> {
+	const pnpManifest = pnpManifests.get(path);
+	if (pnpManifest) return pnpManifest;
 	return JSON.parse(await readFile(path, 'utf8')) as PackageManifest;
 }
 
@@ -184,10 +186,10 @@ export async function detectPackageManagerRoot(projectRoot: string): Promise<str
 
 type PnpApi = {
 	resolveToUnqualified: (request: string, issuer: string) => string | null;
-	setup?: () => void;
 };
 
 const pnpApis = new Map<string, PnpApi>();
+const pnpManifests = new Map<string, PackageManifest>();
 
 function nearestPnpPath(fromDirectory: string): string | undefined {
 	let directory = resolve(fromDirectory);
@@ -208,9 +210,49 @@ function loadPnpApi(pnpPath: string | undefined): PnpApi | undefined {
 	if (cached) return cached;
 
 	const pnpapi = runtimeRequire(pnpPath) as PnpApi;
-	pnpapi.setup?.();
 	pnpApis.set(pnpPath, pnpapi);
 	return pnpapi;
+}
+
+async function readPnpManifest(pnpPath: string, manifestPath: string): Promise<PackageManifest> {
+	const child = spawn(
+		'yarn',
+		[
+			'node',
+			'-e',
+			"process.stdout.write(require('node:fs').readFileSync(process.argv[1], 'utf8'))",
+			manifestPath,
+		],
+		{
+			cwd: dirname(pnpPath),
+			env: isolatedBootstrapEnvironment(),
+			stdio: ['ignore', 'pipe', 'pipe'],
+		}
+	);
+	let output = '';
+	let errors = '';
+	child.stdout?.on('data', (chunk: Buffer) => {
+		output += chunk;
+	});
+	child.stderr?.on('data', (chunk: Buffer) => {
+		errors += chunk;
+	});
+	await new Promise<void>((resolveExit, rejectExit) => {
+		child.once('error', rejectExit);
+		child.once('close', (exitCode) => {
+			if (exitCode === 0) resolveExit();
+			else {
+				rejectExit(
+					new Error(
+						`Could not read PnP manifest ${manifestPath} with yarn node (exit code ${exitCode}): ${errors}`
+					)
+				);
+			}
+		});
+	});
+	const manifest = JSON.parse(output) as PackageManifest;
+	pnpManifests.set(manifestPath, manifest);
+	return manifest;
 }
 
 async function manifestAt(path: string, packageName: string): Promise<string | undefined> {
@@ -234,21 +276,27 @@ async function packageManifestFromNodeModules(
 
 async function packageManifestFromPnp(
 	pnpapi: PnpApi | undefined,
+	pnpPath: string | undefined,
 	packageName: string,
 	fromDirectory: string
 ): Promise<string | undefined> {
-	if (!pnpapi) return undefined;
+	if (!pnpapi || !pnpPath) return undefined;
+	let packageRoot: string | null;
 	try {
-		const packageRoot = pnpapi.resolveToUnqualified(
-			packageName,
-			join(fromDirectory, 'package.json')
-		);
-		return packageRoot
-			? await manifestAt(join(packageRoot, 'package.json'), packageName)
-			: undefined;
+		packageRoot = pnpapi.resolveToUnqualified(packageName, join(fromDirectory, 'package.json'));
 	} catch {
 		return undefined;
 	}
+	if (!packageRoot) return undefined;
+	const manifestPath = join(packageRoot, 'package.json');
+	try {
+		const manifest = await manifestAt(manifestPath, packageName);
+		if (manifest) return manifest;
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOTDIR') throw error;
+	}
+	const manifest = await readPnpManifest(pnpPath, manifestPath);
+	return manifest.name === packageName ? manifestPath : undefined;
 }
 async function packageManifestFromEntry(
 	entry: string,
@@ -272,7 +320,7 @@ export async function resolveInstalledPackageManifest(
 ): Promise<string | undefined> {
 	const pnpapi = loadPnpApi(pnpPath);
 	const requireFrom = createRequire(join(fromDirectory, 'package.json'));
-	const pnpManifest = await packageManifestFromPnp(pnpapi, packageName, fromDirectory);
+	const pnpManifest = await packageManifestFromPnp(pnpapi, pnpPath, packageName, fromDirectory);
 	if (pnpManifest) return pnpManifest;
 	try {
 		const manifestPath = await manifestAt(
@@ -586,34 +634,45 @@ export async function linkBunPackage(projectRoot: string, link: PackageLink): Pr
 type NodeOptionToken = {
 	start: number;
 	end: number;
+	value: string;
 };
 
 function scanNodeOptions(nodeOptions: string): NodeOptionToken[] | undefined {
 	const options: NodeOptionToken[] = [];
 	let tokenStart: number | undefined;
+	let value = '';
 	let inDoubleQuotes = false;
 	for (let index = 0; index < nodeOptions.length; index += 1) {
 		const character = nodeOptions[index]!;
-		if (character === '\t' || character === '\n' || character === '\r') return undefined;
-		if (tokenStart === undefined) {
-			if (character === ' ') continue;
-			tokenStart = index;
-		}
 		if (inDoubleQuotes) {
 			if (character === '\\' && index + 1 < nodeOptions.length) {
+				value += nodeOptions[index + 1]!;
 				index += 1;
 			} else if (character === '"') {
 				inDoubleQuotes = false;
+			} else {
+				value += character;
 			}
-		} else if (character === '"') {
+			continue;
+		}
+		if (character === '\t' || character === '\n' || character === '\r') return undefined;
+		if (character === ' ') {
+			if (tokenStart !== undefined) {
+				options.push({ start: tokenStart, end: index, value });
+				tokenStart = undefined;
+				value = '';
+			}
+			continue;
+		}
+		if (tokenStart === undefined) tokenStart = index;
+		if (character === '"') {
 			inDoubleQuotes = true;
-		} else if (character === ' ') {
-			options.push({ start: tokenStart, end: index });
-			tokenStart = undefined;
+		} else {
+			value += character;
 		}
 	}
 	if (inDoubleQuotes) return undefined;
-	if (tokenStart !== undefined) options.push({ start: tokenStart, end: nodeOptions.length });
+	if (tokenStart !== undefined) options.push({ start: tokenStart, end: nodeOptions.length, value });
 	return options;
 }
 
@@ -637,12 +696,24 @@ export function isolatedBootstrapEnvironment(
 	const removed = new Set<number>();
 	for (let index = 0; index < options.length; index += 1) {
 		const option = options[index]!;
-		const value = nodeOptions.slice(option.start, option.end);
-		const [name] = value.split('=', 1);
-		const loaderName = name.replaceAll('"', '').replaceAll('_', '-');
+		const equals = option.value.indexOf('=');
+		const name = equals === -1 ? option.value : option.value.slice(0, equals);
+		const loaderName = name.replaceAll('_', '-');
 		if (!(loaderName in loaderOptions)) continue;
+
+		if (loaderName === '-r' && equals !== -1) return isolatedEnvironment;
+		if (equals !== -1) {
+			if (option.value.slice(equals + 1).length === 0) return isolatedEnvironment;
+			removed.add(index);
+			continue;
+		}
+
+		const operand = options[index + 1];
+		if (operand === undefined || operand.value.length === 0 || operand.value.startsWith('-')) {
+			return isolatedEnvironment;
+		}
 		removed.add(index);
-		if (!value.includes('=') && index + 1 < options.length) removed.add(index + 1);
+		removed.add(index + 1);
 	}
 	if (removed.size === 0) return isolatedEnvironment;
 	if (removed.size === options.length) {

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -662,6 +662,27 @@ async function snapshotDependencySymlinks(
 }
 
 const childTerminations = new WeakMap<ChildProcess, Promise<void>>();
+const TASKKILL_EXIT_OBSERVATION_TIMEOUT = 100;
+
+function childHasExited(child: ChildProcess): boolean {
+	return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function observeChildExit(child: ChildProcess): Promise<void> {
+	if (childHasExited(child)) return;
+	await new Promise<void>((resolve) => {
+		let timeout: NodeJS.Timeout | undefined;
+		const finish = () => {
+			clearTimeout(timeout);
+			child.removeListener('exit', finish);
+			child.removeListener('close', finish);
+			resolve();
+		};
+		child.once('exit', finish);
+		child.once('close', finish);
+		timeout = setTimeout(finish, TASKKILL_EXIT_OBSERVATION_TIMEOUT);
+	});
+}
 
 type TaskkillLauncher = (pid: number) => ChildProcess;
 
@@ -677,7 +698,7 @@ export function terminateChildProcess(
 	if (!child) return Promise.resolve();
 	const termination = childTerminations.get(child);
 	if (termination) return termination;
-	if (platform === 'win32' && (child.exitCode !== null || child.signalCode !== null)) {
+	if (platform === 'win32' && childHasExited(child)) {
 		const stopped = Promise.resolve();
 		childTerminations.set(child, stopped);
 		return stopped;
@@ -692,8 +713,13 @@ export function terminateChildProcess(
 				taskkill.once('error', rejectExit);
 				taskkill.once('close', resolveExit);
 			});
-			if (exitCode !== 0 && child.exitCode === null && child.signalCode === null) {
-				throw new Error(`taskkill failed while terminating process ${pid} (exit code ${exitCode})`);
+			if (exitCode !== 0 && !childHasExited(child)) {
+				await observeChildExit(child);
+				if (!childHasExited(child)) {
+					throw new Error(
+						`taskkill failed while terminating process ${pid} (exit code ${exitCode})`
+					);
+				}
 			}
 			return;
 		}

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -265,6 +265,22 @@ function awaitPnpManifestRead(
 	});
 }
 
+function awaitPnpManifestReadEviction(read: PnpManifestRead, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) return Promise.reject(abortError(signal));
+	return new Promise<void>((resolveEviction, rejectEviction) => {
+		const finish = () => {
+			signal?.removeEventListener('abort', abort);
+			resolveEviction();
+		};
+		const abort = () => {
+			signal?.removeEventListener('abort', abort);
+			rejectEviction(abortError(signal!));
+		};
+		signal?.addEventListener('abort', abort, { once: true });
+		void read.promise.then(finish, finish);
+	});
+}
+
 async function spawnSupervisedCommand(
 	temporaryRoot: string,
 	file: string,
@@ -465,11 +481,24 @@ async function readPnpManifest(
 	pnpReaderTemporaryRootCreator = createPnpReaderTemporaryRoot,
 	pnpReaderTemporaryRootRemover = removePnpReaderTemporaryRoot
 ): Promise<PackageManifest> {
+	if (signal?.aborted) throw abortError(signal);
 	const cached = pnpManifests.get(manifestPath);
 	if (cached) return cached;
-	if (signal?.aborted) throw abortError(signal);
 
 	let read = pnpManifestReads.get(manifestPath);
+	if (read?.controller.signal.aborted) {
+		await awaitPnpManifestReadEviction(read, signal);
+		if (signal?.aborted) throw abortError(signal);
+		return readPnpManifest(
+			pnpPath,
+			manifestPath,
+			signal,
+			pnpReaderLauncher,
+			pnpReaderTerminator,
+			pnpReaderTemporaryRootCreator,
+			pnpReaderTemporaryRootRemover
+		);
+	}
 	if (!read) {
 		const controller = new AbortController();
 		const newRead: PnpManifestRead = {
@@ -584,6 +613,7 @@ export async function resolveInstalledPackageManifest(
 	pnpReaderTemporaryRootCreator?: typeof createPnpReaderTemporaryRoot,
 	pnpReaderTemporaryRootRemover?: typeof removePnpReaderTemporaryRoot
 ): Promise<string | undefined> {
+	if (signal?.aborted) throw abortError(signal);
 	const pnpapi = loadPnpApi(pnpPath);
 	const requireFrom = createRequire(join(fromDirectory, 'package.json'));
 	const pnpManifest = await packageManifestFromPnp(

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -620,60 +620,69 @@ async function snapshotDependencySymlinks(
 	return [...snapshots.values()];
 }
 
-export async function terminateChildProcess(
+const childTerminations = new WeakMap<ChildProcess, Promise<void>>();
+
+export function terminateChildProcess(
 	child: ChildProcess | undefined,
 	platform = process.platform,
 	gracePeriod = 5_000
 ): Promise<void> {
-	const pid = child?.pid;
-	if (!child || !pid) return;
+	if (!child) return Promise.resolve();
+	const termination = childTerminations.get(child);
+	if (termination) return termination;
+	const pid = child.pid;
+	if (!pid) return Promise.resolve();
 
-	if (platform === 'win32') {
-		const taskkill = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
-		const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
-			taskkill.once('error', rejectExit);
-			taskkill.once('close', resolveExit);
-		});
-		if (exitCode !== 0) {
-			throw new Error(`taskkill failed while terminating process ${pid} (exit code ${exitCode})`);
-		}
-		return;
-	}
-
-	const processGroupAlive = (): boolean => {
-		try {
-			process.kill(-pid, 0);
-			return true;
-		} catch (error: unknown) {
-			return (error as NodeJS.ErrnoException).code !== 'ESRCH';
-		}
-	};
-	const signalProcessGroup = (signal: NodeJS.Signals): void => {
-		try {
-			process.kill(-pid, signal);
-		} catch {
-			try {
-				child.kill(signal);
-			} catch {
-				// The process may have already exited.
+	const promise = (async () => {
+		if (platform === 'win32') {
+			const taskkill = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+			const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
+				taskkill.once('error', rejectExit);
+				taskkill.once('close', resolveExit);
+			});
+			if (exitCode !== 0) {
+				throw new Error(`taskkill failed while terminating process ${pid} (exit code ${exitCode})`);
 			}
+			return;
 		}
-	};
-	const waitForGroupExit = async (): Promise<boolean> => {
-		const deadline = Date.now() + gracePeriod;
-		while (processGroupAlive()) {
-			if (Date.now() >= deadline) return false;
-			await delay(Math.min(50, deadline - Date.now()));
-		}
-		return true;
-	};
 
-	signalProcessGroup('SIGTERM');
-	if (await waitForGroupExit()) return;
-	signalProcessGroup('SIGKILL');
-	if (!(await waitForGroupExit())) {
-		throw new Error(`Process group ${pid} remained alive after SIGKILL`);
-	}
+		const processGroupAlive = (): boolean => {
+			try {
+				process.kill(-pid, 0);
+				return true;
+			} catch (error: unknown) {
+				return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+			}
+		};
+		const signalProcessGroup = (signal: NodeJS.Signals): void => {
+			try {
+				process.kill(-pid, signal);
+			} catch {
+				try {
+					child.kill(signal);
+				} catch {
+					// The process may have already exited.
+				}
+			}
+		};
+		const waitForGroupExit = async (): Promise<boolean> => {
+			const deadline = Date.now() + gracePeriod;
+			while (processGroupAlive()) {
+				if (Date.now() >= deadline) return false;
+				await delay(Math.min(50, deadline - Date.now()));
+			}
+			return true;
+		};
+
+		signalProcessGroup('SIGTERM');
+		if (await waitForGroupExit()) return;
+		signalProcessGroup('SIGKILL');
+		if (!(await waitForGroupExit())) {
+			throw new Error(`Process group ${pid} remained alive after SIGKILL`);
+		}
+	})();
+	childTerminations.set(child, promise);
+	return promise;
 }
 
 class RuntimeSession implements BisectSession {
@@ -742,7 +751,7 @@ class RuntimeSession implements BisectSession {
 		let exitCode: number | null;
 		try {
 			exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
-				const abort = () => void this.stopChild(child);
+				const abort = () => void this.stopChild(child).catch(() => undefined);
 				if (!options.ignoreAbort) this.signal.addEventListener('abort', abort, { once: true });
 				child.once('error', (error) => {
 					if (!options.ignoreAbort) this.signal.removeEventListener('abort', abort);
@@ -1241,7 +1250,9 @@ async function createRuntimeSession(
 			latest.trim(),
 			signal
 		);
-		signal.addEventListener('abort', () => void session.close(), { once: true });
+		signal.addEventListener('abort', () => void session.close().catch(() => undefined), {
+			once: true,
+		});
 		return session;
 	} catch (error) {
 		try {

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -13,6 +13,7 @@ import {
 	writeFile,
 } from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { createInterface } from 'node:readline/promises';
@@ -42,7 +43,6 @@ type PackageManifest = {
 	devDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
 	optionalDependencies?: Record<string, string>;
-	scripts?: Record<string, string>;
 	resolutions?: Record<string, string>;
 };
 
@@ -70,21 +70,27 @@ function commandText(command: readonly string[]): string {
 	return command.map((part) => JSON.stringify(part)).join(' ');
 }
 
-/** Windows only supports direct, foreground Astro development-server scripts. */
-export function isWindowsForegroundDevScript(script: string | undefined): boolean {
-	if (!script || /[;&|<>`$()]/.test(script)) return false;
-	const tokens = script.trim().split(/\s+/);
-	let commandIndex = 0;
-	if (tokens[0] === 'npx' || tokens[0] === 'bunx') {
-		commandIndex = 1;
-	} else if (
-		(tokens[0] === 'pnpm' || tokens[0] === 'yarn' || tokens[0] === 'bun') &&
-		tokens[1] === 'exec'
-	) {
-		commandIndex = 2;
-	}
-	return tokens[commandIndex] === 'astro' && tokens[commandIndex + 1] === 'dev';
+/** Windows launches commands through this supervisor so target processes join a kill-on-close Job Object. */
+export function windowsJobSupervisorCommand(controlFile: string): [string, ...string[]] {
+	return [
+		'powershell.exe',
+		'-NoProfile',
+		'-NonInteractive',
+		'-ExecutionPolicy',
+		'Bypass',
+		'-File',
+		runtimeRequire.resolve('../src/windows-job-supervisor.ps1'),
+		'-ControlFile',
+		controlFile,
+	];
 }
+
+/** Development servers must not consume the terminal input reserved for the bisect prompt. */
+export const developmentServerStdio: ['ignore', 'inherit', 'inherit'] = [
+	'ignore',
+	'inherit',
+	'inherit',
+];
 
 async function readManifest(path: string): Promise<PackageManifest> {
 	return JSON.parse(await readFile(path, 'utf8')) as PackageManifest;
@@ -745,6 +751,29 @@ export class RuntimeSession implements BisectSession {
 		await this.terminate(child);
 	}
 
+	private async spawnCommand(
+		file: string,
+		args: string[],
+		options: NonNullable<Parameters<typeof spawn>[2]>
+	): Promise<ChildProcess> {
+		if (process.platform !== 'win32') return spawn(file, args, options);
+
+		const controlFile = join(this.temporaryRoot, `command-${randomUUID()}.json`);
+		await writeFile(controlFile, JSON.stringify({ file, args }));
+		let child: ChildProcess;
+		try {
+			const [supervisor, ...supervisorArgs] = windowsJobSupervisorCommand(controlFile);
+			child = spawn(supervisor, supervisorArgs, options);
+		} catch (error) {
+			await rm(controlFile, { force: true });
+			throw error;
+		}
+		const cleanControlFile = () => void rm(controlFile, { force: true }).catch(() => undefined);
+		child.once('error', cleanControlFile);
+		child.once('close', cleanControlFile);
+		return child;
+	}
+
 	public async execute(
 		command: readonly string[],
 		cwd: string,
@@ -756,7 +785,7 @@ export class RuntimeSession implements BisectSession {
 
 		let child: ChildProcess;
 		try {
-			child = spawn(file, args, {
+			child = await this.spawnCommand(file, args, {
 				cwd,
 				env: options.env,
 				stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
@@ -788,7 +817,10 @@ export class RuntimeSession implements BisectSession {
 						rejectExit(error);
 					});
 				};
-				if (!options.ignoreAbort) this.signal.addEventListener('abort', abort, { once: true });
+				if (!options.ignoreAbort) {
+					if (this.signal.aborted) abort();
+					else this.signal.addEventListener('abort', abort, { once: true });
+				}
 				child.once('error', (error) => {
 					if (!options.ignoreAbort) this.signal.removeEventListener('abort', abort);
 					rejectExit(
@@ -959,17 +991,9 @@ export class RuntimeSession implements BisectSession {
 	}
 
 	public async runDevServerAndAsk(label: string): Promise<boolean> {
-		if (process.platform === 'win32') {
-			const { scripts } = await readManifest(join(this.projectRoot, 'package.json'));
-			if (!isWindowsForegroundDevScript(scripts?.dev)) {
-				throw new Error(
-					'On Windows, every-astro requires a foreground `astro dev` package script without shell operators.'
-				);
-			}
-		}
-		const child = spawn(this.manager, ['run', 'dev'], {
+		const child = await this.spawnCommand(this.manager, ['run', 'dev'], {
 			cwd: this.projectRoot,
-			stdio: 'inherit',
+			stdio: developmentServerStdio,
 			detached: process.platform !== 'win32',
 		});
 		this.activeChild = child;
@@ -1208,6 +1232,15 @@ export function selectLatestAstroReleaseTag(tags: readonly string[], major: numb
 	return latest.tag;
 }
 
+export function assertFirstAstroReleaseTag(tags: readonly string[], major: number): void {
+	const firstRelease = `astro@${major}.0.0`;
+	if (!tags.some((tag) => tag.trim() === firstRelease)) {
+		throw new Error(
+			`Astro ${major} has no stable first-release bisect boundary (${firstRelease}) in the cloned repository`
+		);
+	}
+}
+
 /** Git revision expression that resolves a release tag to the commit that bisect needs. */
 export function selectLatestAstroReleaseRevision(tags: readonly string[], major: number): string {
 	return `${selectLatestAstroReleaseTag(tags, major)}^{commit}`;
@@ -1275,11 +1308,13 @@ async function createRuntimeSession(
 		const tags = await bootstrap.execute(['git', 'tag', '--list'], repositoryRoot, {
 			capture: true,
 		});
+		const tagList = tags.split(/\r?\n/);
+		assertFirstAstroReleaseTag(tagList, installedAstroMajor);
 		const headManifest = await existingManifest(
 			join(repositoryRoot, 'packages', 'astro', 'package.json')
 		);
 		const latestRevision = selectLatestAstroRevision(
-			tags.split(/\r?\n/),
+			tagList,
 			installedAstroMajor,
 			headManifest?.version
 		);

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -602,18 +602,13 @@ export function isolatedBootstrapEnvironment(
 	const retainedOptions: string[] = [];
 	for (let index = 0; index < options.length; index += 1) {
 		const option = options[index]!;
-		const outerQuote = option.at(0);
-		const normalizedOption =
-			(outerQuote === '"' || outerQuote === "'") && option.at(-1) === outerQuote
-				? option.slice(1, -1)
-				: option;
-		const [name] = normalizedOption.split('=', 1);
-		const loaderName = name.replaceAll('_', '-');
+		const [name] = option.split('=', 1);
+		const loaderName = name.replaceAll('"', '').replaceAll("'", '').replaceAll('_', '-');
 		if (!(loaderName in loaderOptions)) {
 			retainedOptions.push(option);
 			continue;
 		}
-		if (name === normalizedOption) index += 1;
+		if (!option.includes('=')) index += 1;
 	}
 	if (retainedOptions.length > 0) {
 		isolatedEnvironment.NODE_OPTIONS = retainedOptions.join(' ');

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -1,5 +1,4 @@
 import type { ChildProcess, spawn as NodeSpawn } from 'node:child_process';
-import { once } from 'node:events';
 import { existsSync } from 'node:fs';
 import {
 	lstat,
@@ -43,6 +42,7 @@ type PackageManifest = {
 	devDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
 	optionalDependencies?: Record<string, string>;
+	resolutions?: Record<string, string>;
 };
 
 type CommandOptions = {
@@ -96,13 +96,30 @@ const LOCKFILES: readonly [string, PackageManager][] = [
 	['npm-shrinkwrap.json', 'npm'],
 ];
 
+async function findManagerLockfileRoot(
+	manager: PackageManager,
+	fromDirectory: string
+): Promise<string | undefined> {
+	let directory = resolve(fromDirectory);
+	while (true) {
+		if (existsSync(managerLockfile(manager, directory))) return directory;
+		const parent = dirname(directory);
+		if (parent === directory) return undefined;
+		directory = parent;
+	}
+}
+
 async function detectPackageManagerInfo(projectRoot: string): Promise<DetectedPackageManager> {
 	let directory = resolve(projectRoot);
 	while (true) {
 		const manifest = await existingManifest(join(directory, 'package.json'));
 		const configured = manifest?.packageManager?.split('@', 1)[0];
 		if (configured && (PACKAGE_MANAGERS as readonly string[]).includes(configured)) {
-			return { manager: configured as PackageManager, root: directory };
+			const manager = configured as PackageManager;
+			return {
+				manager,
+				root: (await findManagerLockfileRoot(manager, directory)) ?? directory,
+			};
 		}
 		for (const [lockfile, manager] of LOCKFILES) {
 			if (existsSync(join(directory, lockfile))) return { manager, root: directory };
@@ -118,6 +135,11 @@ export async function detectPackageManager(projectRoot: string): Promise<Package
 	return (await detectPackageManagerInfo(projectRoot)).manager;
 }
 
+/** Locate the lockfile root used by the selected package manager. */
+export async function detectPackageManagerRoot(projectRoot: string): Promise<string> {
+	return (await detectPackageManagerInfo(projectRoot)).root;
+}
+
 type PnpApi = {
 	resolveToUnqualified: (request: string, issuer: string) => string | null;
 	setup?: () => void;
@@ -128,8 +150,10 @@ const pnpApis = new Map<string, PnpApi>();
 function nearestPnpPath(fromDirectory: string): string | undefined {
 	let directory = resolve(fromDirectory);
 	while (true) {
-		const pnpPath = join(directory, '.pnp.cjs');
-		if (existsSync(pnpPath)) return pnpPath;
+		for (const filename of ['.pnp.cjs', '.pnp.js']) {
+			const pnpPath = join(directory, filename);
+			if (existsSync(pnpPath)) return pnpPath;
+		}
 		const parent = dirname(directory);
 		if (parent === directory) return undefined;
 		directory = parent;
@@ -226,6 +250,11 @@ export async function resolveInstalledPackageManifest(
 	}
 }
 
+function astroMajorFromVersion(version: string | undefined): number | undefined {
+	const major = version ? Number.parseInt(version.split('.', 1)[0]!, 10) : Number.NaN;
+	return Number.isSafeInteger(major) && major >= 0 ? major : undefined;
+}
+
 /** Find the locally installed Astro version and return its parsed major number. */
 export async function installedAstroMajor(projectRoot: string): Promise<number> {
 	const manifestPath = await resolveInstalledPackageManifest('astro', projectRoot);
@@ -233,8 +262,8 @@ export async function installedAstroMajor(projectRoot: string): Promise<number> 
 		throw new Error(`Could not resolve the installed Astro package from ${projectRoot}`);
 	}
 	const version = (await readManifest(manifestPath)).version;
-	const major = version ? Number.parseInt(version.split('.', 1)[0]!, 10) : Number.NaN;
-	if (!Number.isSafeInteger(major) || major < 0) {
+	const major = astroMajorFromVersion(version);
+	if (major === undefined) {
 		throw new Error(
 			`Installed Astro at ${manifestPath} has an invalid version: ${version ?? 'missing'}`
 		);
@@ -309,6 +338,30 @@ async function walkPackageManifests(
 	}
 }
 
+const BISECT_COMPLETION = /["']?([0-9a-f]{7,40})["']?\s+is the first\s+["']?bad["']?\s+commit\b/i;
+
+/** Extract the completed bisect revision from Git's C-locale completion message. */
+export function parseBisectCompletion(output: string): string | undefined {
+	return BISECT_COMPLETION.exec(output)?.[1];
+}
+
+/** Distinguish a normal bisect advance from unparseable completion or no progress. */
+export function determineBisectProgress(
+	beforeRevision: string,
+	afterRevision: string,
+	output: string
+): string | undefined {
+	const revision = parseBisectCompletion(output);
+	if (BISECT_COMPLETION.test(output)) {
+		if (!revision) throw new Error(`Could not parse Git bisect completion:\n${output}`);
+		return revision;
+	}
+	if (beforeRevision === afterRevision) {
+		throw new Error(`Could not determine Git bisect progress:\n${output}`);
+	}
+	return undefined;
+}
+
 /** Discover public Astro workspace packages without a glob dependency. */
 export async function discoverAstroWorkspacePackages(
 	repositoryRoot: string
@@ -316,6 +369,37 @@ export async function discoverAstroWorkspacePackages(
 	const manifests = new Map<string, string>();
 	await walkPackageManifests(repositoryRoot, manifests);
 	return manifests;
+}
+
+/**
+ * Select local packages that must accompany the installed graph, including
+ * workspace-protocol edges introduced by the checked-out revision.
+ */
+export async function collectAstroWorkspacePackageClosure(
+	packages: ReadonlyMap<string, string>,
+	installedNames: ReadonlySet<string>
+): Promise<Map<string, string>> {
+	const selected = new Map<string, string>();
+	const pending = [...installedNames];
+	while (pending.length > 0) {
+		const name = pending.pop()!;
+		const packageRoot = packages.get(name);
+		if (!packageRoot || selected.has(name)) continue;
+		selected.set(name, packageRoot);
+		const manifest = await readManifest(join(packageRoot, 'package.json'));
+		for (const dependencies of [
+			manifest.dependencies,
+			manifest.optionalDependencies,
+			manifest.peerDependencies,
+		]) {
+			for (const [dependency, descriptor] of Object.entries(dependencies ?? {})) {
+				if (descriptor.startsWith('workspace:') && packages.has(dependency)) {
+					pending.push(dependency);
+				}
+			}
+		}
+	}
+	return selected;
 }
 
 export function abortError(signal: AbortSignal): Error {
@@ -326,11 +410,16 @@ export function abortError(signal: AbortSignal): Error {
 	return error;
 }
 
-async function isYarnBerry(projectRoot: string): Promise<boolean> {
-	if (existsSync(join(projectRoot, '.yarnrc.yml'))) return true;
-	const manager = (await readManifest(join(projectRoot, 'package.json'))).packageManager;
-	const version = manager?.match(/^yarn@(\d+)/)?.[1];
-	return version !== undefined && Number(version) >= 2;
+async function isYarnBerry(projectRoot: string, managerRoot: string): Promise<boolean> {
+	let directory = resolve(projectRoot);
+	while (true) {
+		if (existsSync(join(directory, '.yarnrc.yml'))) return true;
+		const manager = (await existingManifest(join(directory, 'package.json')))?.packageManager;
+		const version = manager?.match(/^yarn@(\d+)/)?.[1];
+		if (version !== undefined && Number(version) >= 2) return true;
+		if (directory === managerRoot) return false;
+		directory = dirname(directory);
+	}
 }
 
 type FileSnapshot = {
@@ -412,15 +501,12 @@ export function packageLinkCommands(
 		case 'yarn':
 			return [
 				{
-					command: yarnBerry
-						? ['yarn', 'add', ...links.map(({ name, path }) => `${name}@portal:${path}`)]
-						: [
-								'yarn',
-								'add',
-								'--pure-lockfile',
-								'--ignore-workspace-root-check',
-								...links.map(({ path }) => `link:${path}`),
-							],
+					command: [
+						'yarn',
+						'add',
+						...(!yarnBerry ? ['--pure-lockfile', '--ignore-workspace-root-check'] : []),
+						...links.map(({ name, path }) => `${name}@file:${path}`),
+					],
 					cwd: projectRoot,
 				},
 			];
@@ -515,7 +601,6 @@ async function snapshotDependencySymlinks(
 	const requireFrom = createRequire(join(projectRoot, 'package.json'));
 	const snapshots = new Map<string, DependencySymlinkSnapshot>();
 	for (const packageName of packageNames) {
-		if (packageName !== 'astro' && !packageName.startsWith('@astrojs/')) continue;
 		for (const nodeModules of requireFrom.resolve.paths(packageName) ?? []) {
 			const packagePath = join(nodeModules, packageName);
 			const relativePath = relative(managerRoot, packagePath);
@@ -535,11 +620,66 @@ async function snapshotDependencySymlinks(
 	return [...snapshots.values()];
 }
 
+export async function terminateChildProcess(
+	child: ChildProcess | undefined,
+	platform = process.platform,
+	gracePeriod = 5_000
+): Promise<void> {
+	const pid = child?.pid;
+	if (!child || !pid) return;
+
+	if (platform === 'win32') {
+		const taskkill = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+		const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
+			taskkill.once('error', rejectExit);
+			taskkill.once('close', resolveExit);
+		});
+		if (exitCode !== 0) {
+			throw new Error(`taskkill failed while terminating process ${pid} (exit code ${exitCode})`);
+		}
+		return;
+	}
+
+	const processGroupAlive = (): boolean => {
+		try {
+			process.kill(-pid, 0);
+			return true;
+		} catch (error: unknown) {
+			return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+		}
+	};
+	const signalProcessGroup = (signal: NodeJS.Signals): void => {
+		try {
+			process.kill(-pid, signal);
+		} catch {
+			try {
+				child.kill(signal);
+			} catch {
+				// The process may have already exited.
+			}
+		}
+	};
+	const waitForGroupExit = async (): Promise<boolean> => {
+		const deadline = Date.now() + gracePeriod;
+		while (processGroupAlive()) {
+			if (Date.now() >= deadline) return false;
+			await delay(Math.min(50, deadline - Date.now()));
+		}
+		return true;
+	};
+
+	signalProcessGroup('SIGTERM');
+	if (await waitForGroupExit()) return;
+	signalProcessGroup('SIGKILL');
+	if (!(await waitForGroupExit())) {
+		throw new Error(`Process group ${pid} remained alive after SIGKILL`);
+	}
+}
+
 class RuntimeSession implements BisectSession {
 	private activeChild: ChildProcess | undefined;
 	private readonly bunLinkTargets = new Map<string, string>();
 	private readonly linkedPackages = new Map<string, string>();
-	private bisectActive = false;
 	private closing: Promise<void> | undefined;
 
 	public constructor(
@@ -565,31 +705,7 @@ class RuntimeSession implements BisectSession {
 	}
 
 	private async stopChild(child = this.activeChild): Promise<void> {
-		const pid = child?.pid;
-		if (!child || !pid || child.exitCode !== null) return;
-		const signal = (name: NodeJS.Signals): void => {
-			try {
-				if (process.platform === 'win32') {
-					spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
-				} else {
-					process.kill(-pid, name);
-				}
-			} catch {
-				try {
-					child.kill(name);
-				} catch {
-					// The child may have already exited.
-				}
-			}
-		};
-		const closed = once(child, 'close')
-			.then(() => true)
-			.catch(() => true);
-		signal('SIGTERM');
-		if (!(await Promise.race([closed, delay(5_000).then(() => false)]))) {
-			signal('SIGKILL');
-			await Promise.race([closed, delay(5_000)]).catch(() => undefined);
-		}
+		await terminateChildProcess(child);
 	}
 
 	public async execute(
@@ -649,25 +765,77 @@ class RuntimeSession implements BisectSession {
 		return output;
 	}
 
+	private async materializePackages(
+		packages: ReadonlyMap<string, string>
+	): Promise<Map<string, string>> {
+		const destinationRoot = join(this.temporaryRoot, 'packages');
+		await rm(destinationRoot, { recursive: true, force: true });
+		await mkdir(destinationRoot, { recursive: true });
+
+		const archives = new Map<string, string>();
+		for (const [name, packageRoot] of packages) {
+			const destination = join(destinationRoot, Buffer.from(name).toString('hex'));
+			await this.execute(
+				[
+					process.execPath,
+					this.isolatedCorepackCli,
+					'pnpm',
+					'pack',
+					'--pack-destination',
+					destination,
+				],
+				packageRoot,
+				{ env: isolatedBootstrapEnvironment() }
+			);
+			const archivesInDestination = (await readdir(destination))
+				.filter((entry) => entry.endsWith('.tgz'))
+				.map((entry) => join(destination, entry));
+			if (archivesInDestination.length !== 1) {
+				throw new Error(`Could not materialize exactly one package archive for ${name}`);
+			}
+			archives.set(name, archivesInDestination[0]!);
+		}
+		return archives;
+	}
+
+	private async addYarnResolutions(links: readonly PackageLink[]): Promise<void> {
+		const manifestPath = join(this.managerRoot, 'package.json');
+		const manifest = await readManifest(manifestPath);
+		manifest.resolutions = {
+			...manifest.resolutions,
+			...Object.fromEntries(links.map(({ name, path }) => [name, `file:${path}`])),
+		};
+		await writeFile(manifestPath, `${JSON.stringify(manifest, undefined, '\t')}\n`);
+	}
+
 	private async linkPackages(packages: ReadonlyMap<string, string>): Promise<void> {
-		const links = [...this.installedDependencies].flatMap((name) => {
-			const path = packages.get(name);
-			return path ? [{ name, path }] : [];
-		});
-		if (!links.some(({ name }) => name === 'astro')) {
+		const sourceLinks = [
+			...(await collectAstroWorkspacePackageClosure(packages, this.installedDependencies)),
+		].map(([name, path]) => ({ name, path }));
+		if (!sourceLinks.some(({ name }) => name === 'astro')) {
 			throw new Error(
 				'Astro is not available in both the installed dependencies and this revision'
 			);
 		}
 
 		if (this.manager === 'bun') {
-			for (const link of links) {
+			for (const link of sourceLinks) {
 				this.bunLinkTargets.set(link.name, await linkBunPackage(this.projectRoot, link));
 				this.linkedPackages.set(link.name, link.path);
 			}
 			return;
 		}
 
+		let links: PackageLink[];
+		if (this.manager === 'pnpm') {
+			links = sourceLinks;
+		} else {
+			const archives = await this.materializePackages(
+				new Map(sourceLinks.map(({ name, path }) => [name, path]))
+			);
+			links = sourceLinks.map(({ name }) => ({ name, path: archives.get(name)! }));
+		}
+		if (this.manager === 'yarn') await this.addYarnResolutions(links);
 		for (const { name, path } of links) this.linkedPackages.set(name, path);
 		for (const { command, cwd } of packageLinkCommands(
 			this.manager,
@@ -717,12 +885,12 @@ class RuntimeSession implements BisectSession {
 		await this.linkPackages(await discoverAstroWorkspacePackages(this.repositoryRoot));
 	}
 
-	private async prompt(label: string): Promise<boolean> {
+	private async prompt(label: string, signal: AbortSignal): Promise<boolean> {
 		const readline = createInterface({ input: process.stdin, output: process.stdout });
 		try {
 			while (true) {
 				const response = (
-					await readline.question(`${label}: is the bug present? [y/n] `, { signal: this.signal })
+					await readline.question(`${label}: is the bug present? [y/n] `, { signal })
 				)
 					.trim()
 					.toLowerCase();
@@ -743,6 +911,7 @@ class RuntimeSession implements BisectSession {
 			detached: process.platform !== 'win32',
 		});
 		this.activeChild = child;
+		const promptController = new AbortController();
 		const earlyExit = new Promise<never>((_, reject) => {
 			child.once('error', (error) =>
 				reject(
@@ -755,17 +924,23 @@ class RuntimeSession implements BisectSession {
 				reject(new CommandError([this.manager, 'run', 'dev'], this.projectRoot, code, ''))
 			);
 		});
+		let promptWork: Promise<boolean> | undefined;
 		try {
 			await Promise.race([delay(100, undefined, { signal: this.signal }), earlyExit]);
-			return await Promise.race([this.prompt(label), earlyExit]);
+			promptWork = this.prompt(label, AbortSignal.any([this.signal, promptController.signal]));
+			return await Promise.race([promptWork, earlyExit]);
 		} finally {
+			promptController.abort('The development server exited before the prompt completed.');
+			await promptWork?.catch(() => undefined);
 			await this.stopChild(child);
 			if (this.activeChild === child) this.activeChild = undefined;
 		}
 	}
 
 	public async startBisect(good: string, bad: string): Promise<void> {
-		await this.execute(['git', 'bisect', 'start', bad, good], this.repositoryRoot);
+		await this.execute(['git', 'bisect', 'start', bad, good], this.repositoryRoot, {
+			env: { ...process.env, LC_ALL: 'C', LANG: 'C' },
+		});
 		this.bisectActive = true;
 	}
 
@@ -776,12 +951,32 @@ class RuntimeSession implements BisectSession {
 	}
 
 	public async markCurrent(isBad: boolean): Promise<string | undefined> {
+		const environment = { ...process.env, LC_ALL: 'C', LANG: 'C' };
+		const beforeRevision = (
+			await this.execute(['git', 'rev-parse', 'HEAD'], this.repositoryRoot, {
+				capture: true,
+				env: environment,
+			})
+		).trim();
 		const output = await this.execute(
 			['git', 'bisect', isBad ? 'bad' : 'good'],
 			this.repositoryRoot,
-			{ capture: true }
+			{ capture: true, env: environment }
 		);
-		return output.match(/\b([0-9a-f]{40}) is the first bad commit\b/i)?.[1];
+		const afterRevision = (
+			await this.execute(['git', 'rev-parse', 'HEAD'], this.repositoryRoot, {
+				capture: true,
+				env: environment,
+			})
+		).trim();
+		const revision = determineBisectProgress(beforeRevision, afterRevision, output);
+		if (!revision) return undefined;
+		return (
+			await this.execute(['git', 'rev-parse', `${revision}^{commit}`], this.repositoryRoot, {
+				capture: true,
+				env: environment,
+			})
+		).trim();
 	}
 
 	private async unlinkPackages(): Promise<void> {
@@ -956,6 +1151,16 @@ export function selectLatestAstroReleaseRevision(tags: readonly string[], major:
 	return `${selectLatestAstroReleaseTag(tags, major)}^{commit}`;
 }
 
+export function selectLatestAstroRevision(
+	tags: readonly string[],
+	major: number,
+	headAstroVersion: string | undefined
+): string {
+	return astroMajorFromVersion(headAstroVersion) === major
+		? 'HEAD'
+		: selectLatestAstroReleaseRevision(tags, major);
+}
+
 async function createRuntimeSession(
 	projectRoot: string,
 	managerInfo: DetectedPackageManager,
@@ -972,7 +1177,7 @@ async function createRuntimeSession(
 		originalManagerLock,
 		originalDependencySymlinks,
 	] = await Promise.all([
-		isYarnBerry(managerRoot),
+		isYarnBerry(projectRoot, managerRoot),
 		snapshotFile(join(managerRoot, 'package.json')),
 		snapshotFile(join(projectRoot, 'package.json')),
 		snapshotFile(managerLockPath),
@@ -1008,9 +1213,13 @@ async function createRuntimeSession(
 		const tags = await bootstrap.execute(['git', 'tag', '--list'], repositoryRoot, {
 			capture: true,
 		});
-		const latestRevision = selectLatestAstroReleaseRevision(
+		const headManifest = await existingManifest(
+			join(repositoryRoot, 'packages', 'astro', 'package.json')
+		);
+		const latestRevision = selectLatestAstroRevision(
 			tags.split(/\r?\n/),
-			installedAstroMajor
+			installedAstroMajor,
+			headManifest?.version
 		);
 		const latest = await bootstrap.execute(['git', 'rev-parse', latestRevision], repositoryRoot, {
 			capture: true,
@@ -1035,7 +1244,15 @@ async function createRuntimeSession(
 		signal.addEventListener('abort', () => void session.close(), { once: true });
 		return session;
 	} catch (error) {
-		await rm(temporaryRoot, { recursive: true, force: true });
+		try {
+			await rm(temporaryRoot, { recursive: true, force: true });
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				'Could not create every-astro runtime session and remove its temporary directory',
+				{ cause: error }
+			);
+		}
 		throw error;
 	}
 }

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -214,10 +214,20 @@ function loadPnpApi(pnpPath: string | undefined): PnpApi | undefined {
 	return pnpapi;
 }
 
-async function readPnpManifest(pnpPath: string, manifestPath: string): Promise<PackageManifest> {
+async function readPnpManifest(
+	pnpPath: string,
+	manifestPath: string,
+	signal?: AbortSignal
+): Promise<PackageManifest> {
+	const cached = pnpManifests.get(manifestPath);
+	if (cached) return cached;
+	if (signal?.aborted) throw abortError(signal);
+
 	const child = spawn(
-		'yarn',
+		process.execPath,
 		[
+			corepackCli,
+			'yarn',
 			'node',
 			'-e',
 			"process.stdout.write(require('node:fs').readFileSync(process.argv[1], 'utf8'))",
@@ -225,6 +235,7 @@ async function readPnpManifest(pnpPath: string, manifestPath: string): Promise<P
 		],
 		{
 			cwd: dirname(pnpPath),
+			detached: process.platform !== 'win32',
 			env: isolatedBootstrapEnvironment(),
 			stdio: ['ignore', 'pipe', 'pipe'],
 		}
@@ -237,19 +248,43 @@ async function readPnpManifest(pnpPath: string, manifestPath: string): Promise<P
 	child.stderr?.on('data', (chunk: Buffer) => {
 		errors += chunk;
 	});
-	await new Promise<void>((resolveExit, rejectExit) => {
-		child.once('error', rejectExit);
-		child.once('close', (exitCode) => {
-			if (exitCode === 0) resolveExit();
-			else {
-				rejectExit(
-					new Error(
-						`Could not read PnP manifest ${manifestPath} with yarn node (exit code ${exitCode}): ${errors}`
-					)
-				);
-			}
-		});
+	const closed = new Promise<void>((resolveClose) => {
+		child.once('close', () => resolveClose());
 	});
+	const completion = new Promise<number | null>((resolveExit, rejectExit) => {
+		child.once('error', rejectExit);
+		child.once('close', resolveExit);
+	});
+	let abortCompletion: Promise<void> | undefined;
+	let rejectAbort!: (reason: unknown) => void;
+	const aborted = new Promise<never>((_resolveAbort, reject) => {
+		rejectAbort = reject;
+	});
+	const abort = () => {
+		abortCompletion ??= (async () => {
+			await terminateChildProcess(child);
+			await closed;
+		})();
+		void abortCompletion.then(
+			() => rejectAbort(abortError(signal!)),
+			(error: unknown) => rejectAbort(error)
+		);
+	};
+	if (signal) signal.addEventListener('abort', abort, { once: true });
+	try {
+		const exitCode = await Promise.race([completion, aborted]);
+		if (signal?.aborted) {
+			await abortCompletion;
+			throw abortError(signal);
+		}
+		if (exitCode !== 0) {
+			throw new Error(
+				`Could not read PnP manifest ${manifestPath} with Corepack Yarn (exit code ${exitCode}): ${errors}`
+			);
+		}
+	} finally {
+		signal?.removeEventListener('abort', abort);
+	}
 	const manifest = JSON.parse(output) as PackageManifest;
 	pnpManifests.set(manifestPath, manifest);
 	return manifest;
@@ -278,7 +313,8 @@ async function packageManifestFromPnp(
 	pnpapi: PnpApi | undefined,
 	pnpPath: string | undefined,
 	packageName: string,
-	fromDirectory: string
+	fromDirectory: string,
+	signal?: AbortSignal
 ): Promise<string | undefined> {
 	if (!pnpapi || !pnpPath) return undefined;
 	let packageRoot: string | null;
@@ -295,7 +331,7 @@ async function packageManifestFromPnp(
 	} catch (error: unknown) {
 		if ((error as NodeJS.ErrnoException).code !== 'ENOTDIR') throw error;
 	}
-	const manifest = await readPnpManifest(pnpPath, manifestPath);
+	const manifest = await readPnpManifest(pnpPath, manifestPath, signal);
 	return manifest.name === packageName ? manifestPath : undefined;
 }
 async function packageManifestFromEntry(
@@ -316,11 +352,18 @@ async function packageManifestFromEntry(
 export async function resolveInstalledPackageManifest(
 	packageName: string,
 	fromDirectory: string,
-	pnpPath = nearestPnpPath(fromDirectory)
+	pnpPath = nearestPnpPath(fromDirectory),
+	signal?: AbortSignal
 ): Promise<string | undefined> {
 	const pnpapi = loadPnpApi(pnpPath);
 	const requireFrom = createRequire(join(fromDirectory, 'package.json'));
-	const pnpManifest = await packageManifestFromPnp(pnpapi, pnpPath, packageName, fromDirectory);
+	const pnpManifest = await packageManifestFromPnp(
+		pnpapi,
+		pnpPath,
+		packageName,
+		fromDirectory,
+		signal
+	);
 	if (pnpManifest) return pnpManifest;
 	try {
 		const manifestPath = await manifestAt(
@@ -346,8 +389,16 @@ function astroMajorFromVersion(version: string | undefined): number | undefined 
 }
 
 /** Find the locally installed Astro version and return its parsed major number. */
-export async function installedAstroMajor(projectRoot: string): Promise<number> {
-	const manifestPath = await resolveInstalledPackageManifest('astro', projectRoot);
+export async function installedAstroMajor(
+	projectRoot: string,
+	signal?: AbortSignal
+): Promise<number> {
+	const manifestPath = await resolveInstalledPackageManifest(
+		'astro',
+		projectRoot,
+		undefined,
+		signal
+	);
 	if (!manifestPath) {
 		throw new Error(`Could not resolve the installed Astro package from ${projectRoot}`);
 	}
@@ -374,7 +425,11 @@ function packageDependencies(manifest: PackageManifest, includeDevDependencies =
  * Walk manifests resolved from the project rather than assuming a node_modules layout.
  * This works with scoped names, pnpm's virtual store, and package export maps.
  */
-export async function collectInstalledDependencyNames(projectRoot: string): Promise<Set<string>> {
+export async function collectInstalledDependencyNames(
+	projectRoot: string,
+	signal?: AbortSignal
+): Promise<Set<string>> {
+	if (signal?.aborted) throw abortError(signal);
 	const rootManifest = await readManifest(join(projectRoot, 'package.json'));
 	const pnpPath = nearestPnpPath(projectRoot);
 	loadPnpApi(pnpPath);
@@ -390,7 +445,8 @@ export async function collectInstalledDependencyNames(projectRoot: string): Prom
 		const manifestPath = await resolveInstalledPackageManifest(
 			dependency.name,
 			dependency.from,
-			pnpPath
+			pnpPath,
+			signal
 		);
 		if (!manifestPath || visitedManifests.has(manifestPath)) continue;
 
@@ -1544,8 +1600,8 @@ export async function createRuntimeDependencies(
 	const absoluteProjectRoot = resolve(projectRoot);
 	const [managerInfo, major, installedDependencies] = await Promise.all([
 		detectPackageManagerInfo(absoluteProjectRoot),
-		installedAstroMajor(absoluteProjectRoot),
-		collectInstalledDependencyNames(absoluteProjectRoot),
+		installedAstroMajor(absoluteProjectRoot, signal),
+		collectInstalledDependencyNames(absoluteProjectRoot, signal),
 	]);
 	let session: Promise<RuntimeSession> | undefined;
 	return {

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -190,6 +190,7 @@ type PnpApi = {
 
 const pnpApis = new Map<string, PnpApi>();
 const pnpManifests = new Map<string, PackageManifest>();
+const pnpManifestReads = new Map<string, PnpManifestRead>();
 
 function nearestPnpPath(fromDirectory: string): string | undefined {
 	let directory = resolve(fromDirectory);
@@ -215,6 +216,54 @@ function loadPnpApi(pnpPath: string | undefined): PnpApi | undefined {
 }
 
 type PnpReaderLaunchObserver = (child: ChildProcess) => void;
+
+type PnpManifestRead = {
+	controller: AbortController;
+	consumers: Map<symbol, AbortSignal | undefined>;
+	promise: Promise<PackageManifest>;
+	settled: boolean;
+};
+
+function awaitPnpManifestRead(
+	read: PnpManifestRead,
+	signal?: AbortSignal
+): Promise<PackageManifest> {
+	if (signal?.aborted) return Promise.reject(abortError(signal));
+	const consumer = Symbol();
+	read.consumers.set(consumer, signal);
+	return new Promise<PackageManifest>((resolveRead, rejectRead) => {
+		let finished = false;
+		const release = (aborted = false): boolean => {
+			if (finished) return false;
+			finished = true;
+			signal?.removeEventListener('abort', abort);
+			read.consumers.delete(consumer);
+			const cancelsRead = aborted && !read.settled && read.consumers.size === 0;
+			if (cancelsRead) read.controller.abort();
+			return (
+				aborted &&
+				!read.settled &&
+				(cancelsRead || [...read.consumers.values()].every((other) => other === signal))
+			);
+		};
+		const abort = () => {
+			if (!release(true)) rejectRead(abortError(signal!));
+		};
+		signal?.addEventListener('abort', abort, { once: true });
+		void read.promise.then(
+			(manifest) => {
+				release();
+				if (signal?.aborted) rejectRead(abortError(signal));
+				else resolveRead(manifest);
+			},
+			(error: unknown) => {
+				release();
+				if (signal?.aborted) rejectRead(abortError(signal));
+				else rejectRead(error);
+			}
+		);
+	});
+}
 
 async function spawnSupervisedCommand(
 	temporaryRoot: string,
@@ -256,7 +305,7 @@ async function removePnpReaderTemporaryRoot(temporaryRoot: string): Promise<void
 	await rm(temporaryRoot, { recursive: true, force: true });
 }
 
-async function readPnpManifest(
+async function readPnpManifestUncached(
 	pnpPath: string,
 	manifestPath: string,
 	signal?: AbortSignal,
@@ -265,8 +314,6 @@ async function readPnpManifest(
 	pnpReaderTemporaryRootCreator = createPnpReaderTemporaryRoot,
 	pnpReaderTemporaryRootRemover = removePnpReaderTemporaryRoot
 ): Promise<PackageManifest> {
-	const cached = pnpManifests.get(manifestPath);
-	if (cached) return cached;
 	if (signal?.aborted) throw abortError(signal);
 
 	let temporaryRoot: string | undefined;
@@ -404,9 +451,56 @@ async function readPnpManifest(
 			);
 		}
 	}
+
 	if (primaryError !== undefined) throw primaryError;
-	pnpManifests.set(manifestPath, manifest!);
 	return manifest!;
+}
+
+async function readPnpManifest(
+	pnpPath: string,
+	manifestPath: string,
+	signal?: AbortSignal,
+	pnpReaderLauncher = spawnSupervisedCommand,
+	pnpReaderTerminator: ChildTerminator = terminateChildProcess,
+	pnpReaderTemporaryRootCreator = createPnpReaderTemporaryRoot,
+	pnpReaderTemporaryRootRemover = removePnpReaderTemporaryRoot
+): Promise<PackageManifest> {
+	const cached = pnpManifests.get(manifestPath);
+	if (cached) return cached;
+	if (signal?.aborted) throw abortError(signal);
+
+	let read = pnpManifestReads.get(manifestPath);
+	if (!read) {
+		const controller = new AbortController();
+		const newRead: PnpManifestRead = {
+			controller,
+			consumers: new Map<symbol, AbortSignal | undefined>(),
+			promise: undefined!,
+			settled: false,
+		};
+		newRead.promise = readPnpManifestUncached(
+			pnpPath,
+			manifestPath,
+			controller.signal,
+			pnpReaderLauncher,
+			pnpReaderTerminator,
+			pnpReaderTemporaryRootCreator,
+			pnpReaderTemporaryRootRemover
+		)
+			.then((manifest) => {
+				pnpManifests.set(manifestPath, manifest);
+				return manifest;
+			})
+			.finally(() => {
+				newRead.settled = true;
+				if (pnpManifestReads.get(manifestPath) === newRead) {
+					pnpManifestReads.delete(manifestPath);
+				}
+			});
+		pnpManifestReads.set(manifestPath, newRead);
+		read = newRead;
+	}
+	return awaitPnpManifestRead(read, signal);
 }
 
 async function manifestAt(path: string, packageName: string): Promise<string | undefined> {
@@ -928,15 +1022,48 @@ export function isolatedBootstrapEnvironment(
 	return isolatedEnvironment;
 }
 
+async function windowsDirectorySymlinkType(path: string): Promise<'dir' | 'junction'> {
+	const child = spawn(
+		'powershell.exe',
+		[
+			'-NoProfile',
+			'-NonInteractive',
+			'-Command',
+			'(Get-Item -LiteralPath $args[0] -Force).LinkType',
+			path,
+		],
+		{ stdio: ['ignore', 'pipe', 'pipe'] }
+	);
+	let output = '';
+	let errors = '';
+	child.stdout?.on('data', (chunk: Buffer) => {
+		output += chunk;
+	});
+	child.stderr?.on('data', (chunk: Buffer) => {
+		errors += chunk;
+	});
+	const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
+		child.once('error', rejectExit);
+		child.once('close', resolveExit);
+	});
+	if (exitCode !== 0) {
+		throw new Error(`Could not inspect Windows directory link ${path}: ${errors}`);
+	}
+	switch (output.trim()) {
+		case 'SymbolicLink':
+			return 'dir';
+		case 'Junction':
+			return 'junction';
+		default:
+			throw new Error(`Could not identify Windows directory link ${path}: ${output}`);
+	}
+}
+
 export type DependencySymlinkSnapshot = {
 	path: string;
 	target: string;
 	type: 'dir' | 'junction';
 };
-
-export function dependencySymlinkType(platform = process.platform): 'dir' | 'junction' {
-	return platform === 'win32' ? 'junction' : 'dir';
-}
 
 /** Restore a dependency link exactly as it was before the bisect session. */
 export async function restoreDependencySymlink(snapshot: DependencySymlinkSnapshot): Promise<void> {
@@ -945,7 +1072,7 @@ export async function restoreDependencySymlink(snapshot: DependencySymlinkSnapsh
 	await symlink(snapshot.target, snapshot.path, snapshot.type);
 }
 
-async function snapshotDependencySymlinks(
+export async function snapshotDependencySymlinks(
 	projectRoot: string,
 	managerRoot: string,
 	packageNames: ReadonlySet<string>
@@ -962,7 +1089,8 @@ async function snapshotDependencySymlinks(
 				snapshots.set(packagePath, {
 					path: packagePath,
 					target: await readlink(packagePath),
-					type: dependencySymlinkType(),
+					type:
+						process.platform === 'win32' ? await windowsDirectorySymlinkType(packagePath) : 'dir',
 				});
 			} catch (error: unknown) {
 				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
@@ -973,10 +1101,35 @@ async function snapshotDependencySymlinks(
 }
 
 const childTerminations = new WeakMap<ChildProcess, Promise<void>>();
+const childCloses = new WeakMap<ChildProcess, { listener: () => void; promise: Promise<void> }>();
 const TASKKILL_EXIT_OBSERVATION_TIMEOUT = 100;
 
 function childHasExited(child: ChildProcess): boolean {
-	return child.exitCode !== null || child.signalCode !== null;
+	return (
+		(child.exitCode !== null && child.exitCode !== undefined) ||
+		(child.signalCode !== null && child.signalCode !== undefined)
+	);
+}
+
+function observeChildClose(child: ChildProcess): Promise<void> {
+	const observed = childCloses.get(child);
+	if (observed) return observed.promise;
+	if (childHasExited(child)) return Promise.resolve();
+	const close = Promise.withResolvers<void>();
+	const listener = () => {
+		childCloses.delete(child);
+		close.resolve();
+	};
+	child.once('close', listener);
+	childCloses.set(child, { listener, promise: close.promise });
+	return close.promise;
+}
+
+function forgetChildClose(child: ChildProcess): void {
+	const observed = childCloses.get(child);
+	if (!observed) return;
+	child.removeListener('close', observed.listener);
+	childCloses.delete(child);
 }
 
 async function observeChildExit(child: ChildProcess): Promise<void> {
@@ -1009,30 +1162,37 @@ export function terminateChildProcess(
 	if (!child) return Promise.resolve();
 	const termination = childTerminations.get(child);
 	if (termination) return termination;
+	const close = observeChildClose(child);
 	if (platform === 'win32' && childHasExited(child)) {
-		const stopped = Promise.resolve();
-		childTerminations.set(child, stopped);
-		return stopped;
+		childTerminations.set(child, close);
+		return close;
 	}
 	const pid = child.pid;
-	if (!pid) return Promise.resolve();
+	if (!pid) return platform === 'win32' ? close : Promise.resolve();
 
 	const promise = (async () => {
 		if (platform === 'win32') {
-			const taskkill = taskkillLauncher(pid);
-			const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
-				taskkill.once('error', rejectExit);
-				taskkill.once('close', resolveExit);
-			});
-			if (exitCode !== 0 && !childHasExited(child)) {
-				await observeChildExit(child);
-				if (!childHasExited(child)) {
-					throw new Error(
-						`taskkill failed while terminating process ${pid} (exit code ${exitCode})`
-					);
+			let stopped = false;
+			try {
+				const taskkill = taskkillLauncher(pid);
+				const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
+					taskkill.once('error', rejectExit);
+					taskkill.once('close', resolveExit);
+				});
+				if (exitCode !== 0 && !childHasExited(child)) {
+					await observeChildExit(child);
+					if (!childHasExited(child)) {
+						throw new Error(
+							`taskkill failed while terminating process ${pid} (exit code ${exitCode})`
+						);
+					}
 				}
+				await close;
+				stopped = true;
+				return;
+			} finally {
+				if (!stopped) forgetChildClose(child);
 			}
-			return;
 		}
 
 		const processGroupAlive = (): boolean => {
@@ -1124,9 +1284,11 @@ export class RuntimeSession implements BisectSession {
 		args: string[],
 		options: NonNullable<Parameters<typeof spawn>[2]>
 	): Promise<ChildProcess> {
-		return this.commandSpawner
+		const child = await (this.commandSpawner
 			? this.commandSpawner(file, args, options)
-			: spawnSupervisedCommand(this.temporaryRoot, file, args, options);
+			: spawnSupervisedCommand(this.temporaryRoot, file, args, options));
+		observeChildClose(child);
+		return child;
 	}
 
 	public async execute(
@@ -1366,14 +1528,27 @@ export class RuntimeSession implements BisectSession {
 			);
 		});
 		let promptWork: Promise<boolean> | undefined;
+		let primaryError: unknown;
 		try {
 			await Promise.race([delay(100, undefined, { signal: this.signal }), earlyExit]);
 			promptWork = this.prompt(label, AbortSignal.any([this.signal, promptController.signal]));
 			return await Promise.race([promptWork, earlyExit]);
+		} catch (error) {
+			primaryError = error;
+			throw error;
 		} finally {
 			promptController.abort('The development server exited before the prompt completed.');
 			await promptWork?.catch(() => undefined);
-			await this.stopChild(child);
+			try {
+				await this.stopChild(child);
+			} catch (cleanupError) {
+				if (primaryError === undefined) throw cleanupError;
+				throw new AggregateError(
+					[primaryError, cleanupError],
+					'Could not complete the development-server prompt and stop its process',
+					{ cause: primaryError }
+				);
+			}
 			if (this.activeChild === child) this.activeChild = undefined;
 		}
 	}

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -602,12 +602,17 @@ export function isolatedBootstrapEnvironment(
 	const retainedOptions: string[] = [];
 	for (let index = 0; index < options.length; index += 1) {
 		const option = options[index]!;
-		const [name] = option.split('=', 1);
+		const outerQuote = option.at(0);
+		const normalizedOption =
+			(outerQuote === '"' || outerQuote === "'") && option.at(-1) === outerQuote
+				? option.slice(1, -1)
+				: option;
+		const [name] = normalizedOption.split('=', 1);
 		if (!(name in loaderOptions)) {
 			retainedOptions.push(option);
 			continue;
 		}
-		if (name === option) index += 1;
+		if (name === normalizedOption) index += 1;
 	}
 	if (retainedOptions.length > 0) {
 		isolatedEnvironment.NODE_OPTIONS = retainedOptions.join(' ');

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -42,6 +42,7 @@ type PackageManifest = {
 	devDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
 	optionalDependencies?: Record<string, string>;
+	scripts?: Record<string, string>;
 	resolutions?: Record<string, string>;
 };
 
@@ -67,6 +68,22 @@ class CommandError extends Error {
 
 function commandText(command: readonly string[]): string {
 	return command.map((part) => JSON.stringify(part)).join(' ');
+}
+
+/** Windows only supports direct, foreground Astro development-server scripts. */
+export function isWindowsForegroundDevScript(script: string | undefined): boolean {
+	if (!script || /[;&|<>`$()]/.test(script)) return false;
+	const tokens = script.trim().split(/\s+/);
+	let commandIndex = 0;
+	if (tokens[0] === 'npx' || tokens[0] === 'bunx') {
+		commandIndex = 1;
+	} else if (
+		(tokens[0] === 'pnpm' || tokens[0] === 'yarn' || tokens[0] === 'bun') &&
+		tokens[1] === 'exec'
+	) {
+		commandIndex = 2;
+	}
+	return tokens[commandIndex] === 'astro' && tokens[commandIndex + 1] === 'dev';
 }
 
 async function readManifest(path: string): Promise<PackageManifest> {
@@ -686,10 +703,15 @@ export function terminateChildProcess(
 		}
 	})();
 	childTerminations.set(child, promise);
+	void promise.catch(() => {
+		if (childTerminations.get(child) === promise) childTerminations.delete(child);
+	});
 	return promise;
 }
 
-class RuntimeSession implements BisectSession {
+type ChildTerminator = (child: ChildProcess | undefined) => Promise<void>;
+
+export class RuntimeSession implements BisectSession {
 	private activeChild: ChildProcess | undefined;
 	private bisectActive = false;
 	private readonly bunLinkTargets = new Map<string, string>();
@@ -711,7 +733,8 @@ class RuntimeSession implements BisectSession {
 		private readonly originalDependencySymlinks: readonly DependencySymlinkSnapshot[],
 		private readonly installedDependencies: ReadonlySet<string>,
 		private readonly latest: string,
-		private readonly signal: AbortSignal
+		private readonly signal: AbortSignal,
+		private readonly terminate: ChildTerminator = terminateChildProcess
 	) {}
 
 	public async latestRevision(): Promise<string> {
@@ -719,7 +742,7 @@ class RuntimeSession implements BisectSession {
 	}
 
 	private async stopChild(child = this.activeChild): Promise<void> {
-		await terminateChildProcess(child);
+		await this.terminate(child);
 	}
 
 	public async execute(
@@ -754,9 +777,17 @@ class RuntimeSession implements BisectSession {
 		}
 
 		let exitCode: number | null;
+		let terminationFailed = false;
 		try {
 			exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
-				const abort = () => void this.stopChild(child).catch(() => undefined);
+				let abortTermination: Promise<void> | undefined;
+				const abort = () => {
+					abortTermination = this.stopChild(child);
+					void abortTermination.catch((error: unknown) => {
+						terminationFailed = true;
+						rejectExit(error);
+					});
+				};
 				if (!options.ignoreAbort) this.signal.addEventListener('abort', abort, { once: true });
 				child.once('error', (error) => {
 					if (!options.ignoreAbort) this.signal.removeEventListener('abort', abort);
@@ -766,11 +797,21 @@ class RuntimeSession implements BisectSession {
 				});
 				child.once('close', (code) => {
 					if (!options.ignoreAbort) this.signal.removeEventListener('abort', abort);
-					resolveExit(code);
+					if (abortTermination) {
+						void abortTermination.then(
+							() => resolveExit(code),
+							(error: unknown) => {
+								terminationFailed = true;
+								rejectExit(error);
+							}
+						);
+					} else {
+						resolveExit(code);
+					}
 				});
 			});
 		} finally {
-			if (this.activeChild === child) this.activeChild = undefined;
+			if (!terminationFailed && this.activeChild === child) this.activeChild = undefined;
 		}
 		if (this.signal.aborted && !options.ignoreAbort) throw abortError(this.signal);
 		if (exitCode !== 0) {
@@ -918,7 +959,14 @@ class RuntimeSession implements BisectSession {
 	}
 
 	public async runDevServerAndAsk(label: string): Promise<boolean> {
-		if (this.signal.aborted) throw abortError(this.signal);
+		if (process.platform === 'win32') {
+			const { scripts } = await readManifest(join(this.projectRoot, 'package.json'));
+			if (!isWindowsForegroundDevScript(scripts?.dev)) {
+				throw new Error(
+					'On Windows, every-astro requires a foreground `astro dev` package script without shell operators.'
+				);
+			}
+		}
 		const child = spawn(this.manager, ['run', 'dev'], {
 			cwd: this.projectRoot,
 			stdio: 'inherit',

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -47,6 +47,7 @@ type PackageManifest = {
 
 type CommandOptions = {
 	capture?: boolean;
+	env?: NodeJS.ProcessEnv;
 	ignoreAbort?: boolean;
 };
 
@@ -405,17 +406,16 @@ export function packageLinkCommands(
 				},
 			];
 		case 'bun':
-			return [
-				{
-					command: ['bun', 'add', '--no-save', ...links.map(({ path }) => path)],
-					cwd: projectRoot,
-				},
-			];
+			return [];
 		case 'yarn':
 			return [
 				{
 					command: yarnBerry
-						? ['yarn', 'link', ...links.map(({ path }) => path)]
+						? [
+								'yarn',
+								'add',
+								...links.map(({ name, path }) => `${name}@portal:${path}`),
+							]
 						: [
 								'yarn',
 								'add',
@@ -432,6 +432,39 @@ export function packageLinkCommands(
 				cwd: projectRoot,
 			}));
 	}
+}
+
+async function installedNodeModulesPackagePath(
+	projectRoot: string,
+	packageName: string
+): Promise<string | undefined> {
+	const requireFrom = createRequire(join(projectRoot, 'package.json'));
+	for (const nodeModules of requireFrom.resolve.paths(packageName) ?? []) {
+		const packagePath = join(nodeModules, packageName);
+		if (await manifestAt(join(packagePath, 'package.json'), packageName)) return packagePath;
+	}
+	return undefined;
+}
+
+/** Replace a Bun-installed package with a local package without invoking Bun's registry linker. */
+export async function linkBunPackage(projectRoot: string, link: PackageLink): Promise<string> {
+	const packagePath = await installedNodeModulesPackagePath(projectRoot, link.name);
+	if (!packagePath) {
+		throw new Error(`Could not find the Bun-installed ${link.name} package from ${projectRoot}`);
+	}
+	await rm(packagePath, { recursive: true, force: true });
+	await mkdir(dirname(packagePath), { recursive: true });
+	await symlink(link.path, packagePath, process.platform === 'win32' ? 'junction' : 'dir');
+	return packagePath;
+}
+
+/** Remove the consumer's Node loader hooks from commands that run in the cloned repository. */
+export function isolatedBootstrapEnvironment(
+	environment: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+	const isolatedEnvironment = { ...environment };
+	delete isolatedEnvironment.NODE_OPTIONS;
+	return isolatedEnvironment;
 }
 
 type SymlinkSnapshot = {
@@ -468,6 +501,7 @@ async function snapshotDependencySymlinks(
 
 class RuntimeSession implements BisectSession {
 	private activeChild: ChildProcess | undefined;
+	private readonly bunLinkTargets = new Map<string, string>();
 	private readonly linkedPackages = new Map<string, string>();
 	private bisectActive = false;
 	private closing: Promise<void> | undefined;
@@ -477,6 +511,7 @@ class RuntimeSession implements BisectSession {
 		private readonly managerRoot: string,
 		private readonly repositoryRoot: string,
 		private readonly temporaryRoot: string,
+		private readonly isolatedCorepackCli: string,
 		private readonly manager: PackageManager,
 		private readonly yarnBerry: boolean,
 		private readonly originalManagerManifest: FileSnapshot,
@@ -534,6 +569,7 @@ class RuntimeSession implements BisectSession {
 		try {
 			child = spawn(file, args, {
 				cwd,
+				env: options.env,
 				stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
 				detached: process.platform !== 'win32',
 			});
@@ -588,6 +624,14 @@ class RuntimeSession implements BisectSession {
 			);
 		}
 
+		if (this.manager === 'bun') {
+			for (const link of links) {
+				this.bunLinkTargets.set(link.name, await linkBunPackage(this.projectRoot, link));
+				this.linkedPackages.set(link.name, link.path);
+			}
+			return;
+		}
+
 		for (const { name, path } of links) this.linkedPackages.set(name, path);
 		for (const { command, cwd } of packageLinkCommands(
 			this.manager,
@@ -625,12 +669,14 @@ class RuntimeSession implements BisectSession {
 		await this.execute(['git', 'checkout', '--force', revision], this.repositoryRoot);
 		await this.execute(['git', 'clean', '-fdx'], this.repositoryRoot);
 		await this.execute(
-			[process.execPath, corepackCli, 'pnpm', 'install', '--frozen-lockfile'],
-			this.repositoryRoot
+			[process.execPath, this.isolatedCorepackCli, 'pnpm', 'install', '--frozen-lockfile'],
+			this.repositoryRoot,
+			{ env: isolatedBootstrapEnvironment() }
 		);
 		await this.execute(
-			[process.execPath, corepackCli, 'pnpm', 'run', 'build'],
-			this.repositoryRoot
+			[process.execPath, this.isolatedCorepackCli, 'pnpm', 'run', 'build'],
+			this.repositoryRoot,
+			{ env: isolatedBootstrapEnvironment() }
 		);
 		await this.linkPackages(await discoverAstroWorkspacePackages(this.repositoryRoot));
 	}
@@ -704,6 +750,13 @@ class RuntimeSession implements BisectSession {
 
 	private async unlinkPackages(): Promise<void> {
 		const failures: unknown[] = [];
+		const remove = async (path: string): Promise<void> => {
+			try {
+				await rm(path, { recursive: true, force: true });
+			} catch (error) {
+				failures.push(error);
+			}
+		};
 		const unlink = async (command: string[], cwd: string): Promise<void> => {
 			try {
 				await this.execute(command, cwd, { ignoreAbort: true });
@@ -714,15 +767,19 @@ class RuntimeSession implements BisectSession {
 		for (const [name, path] of this.linkedPackages) {
 			switch (this.manager) {
 				case 'npm':
-				case 'bun':
 					break;
+				case 'bun': {
+					const target = this.bunLinkTargets.get(name);
+					if (target) await remove(target);
+					break;
+				}
 				case 'yarn':
-					if (this.yarnBerry) await unlink(['yarn', 'unlink', name], this.projectRoot);
 					break;
 				case 'pnpm':
 					await unlink(['pnpm', 'unlink', name], this.projectRoot);
 			}
 		}
+		this.bunLinkTargets.clear();
 		if (failures.length > 0) {
 			throw new AggregateError(failures, 'Could not unlink all Astro packages');
 		}
@@ -821,6 +878,25 @@ class RuntimeSession implements BisectSession {
 	}
 }
 
+async function copyCorepackCli(temporaryRoot: string): Promise<string> {
+	const isolatedPackage = join(temporaryRoot, 'node_modules', 'corepack');
+	const isolatedDist = join(isolatedPackage, 'dist');
+	const isolatedCli = join(isolatedDist, 'corepack.js');
+	await mkdir(join(isolatedDist, 'lib'), { recursive: true });
+	await Promise.all([
+		writeFile(
+			join(isolatedPackage, 'package.json'),
+			await readFile(join(dirname(dirname(corepackCli)), 'package.json'))
+		),
+		writeFile(isolatedCli, await readFile(corepackCli)),
+		writeFile(
+			join(isolatedDist, 'lib', 'corepack.cjs'),
+			await readFile(join(dirname(corepackCli), 'lib', 'corepack.cjs'))
+		),
+	]);
+	return isolatedCli;
+}
+
 async function createRuntimeSession(
 	projectRoot: string,
 	managerInfo: DetectedPackageManager,
@@ -850,11 +926,13 @@ async function createRuntimeSession(
 	const temporaryRoot = await mkdtemp(join(tmpdir(), 'every-astro-'));
 	const repositoryRoot = join(temporaryRoot, 'astro');
 	try {
+		const isolatedCorepackCli = await copyCorepackCli(temporaryRoot);
 		const bootstrap = new RuntimeSession(
 			projectRoot,
 			managerRoot,
 			repositoryRoot,
 			temporaryRoot,
+			isolatedCorepackCli,
 			managerInfo.manager,
 			yarnBerry,
 			originalManagerManifest,
@@ -875,6 +953,7 @@ async function createRuntimeSession(
 			managerRoot,
 			repositoryRoot,
 			temporaryRoot,
+			isolatedCorepackCli,
 			managerInfo.manager,
 			yarnBerry,
 			originalManagerManifest,

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -583,31 +583,37 @@ export async function linkBunPackage(projectRoot: string, link: PackageLink): Pr
 	return packagePath;
 }
 
-function splitNodeOptions(nodeOptions: string): string[] | undefined {
-	const options: string[] = [];
+type NodeOptionToken = {
+	start: number;
+	end: number;
+};
+
+function scanNodeOptions(nodeOptions: string): NodeOptionToken[] | undefined {
+	const options: NodeOptionToken[] = [];
 	let tokenStart: number | undefined;
-	let quote: '"' | "'" | undefined;
+	let inDoubleQuotes = false;
 	for (let index = 0; index < nodeOptions.length; index += 1) {
 		const character = nodeOptions[index]!;
+		if (character === '\t' || character === '\n' || character === '\r') return undefined;
 		if (tokenStart === undefined) {
-			if (/\s/.test(character)) continue;
+			if (character === ' ') continue;
 			tokenStart = index;
 		}
-		if (quote !== undefined) {
-			if (quote === '"' && character === '\\' && index + 1 < nodeOptions.length) {
+		if (inDoubleQuotes) {
+			if (character === '\\' && index + 1 < nodeOptions.length) {
 				index += 1;
-			} else if (character === quote) {
-				quote = undefined;
+			} else if (character === '"') {
+				inDoubleQuotes = false;
 			}
-		} else if (character === '"' || character === "'") {
-			quote = character;
-		} else if (/\s/.test(character)) {
-			options.push(nodeOptions.slice(tokenStart, index));
+		} else if (character === '"') {
+			inDoubleQuotes = true;
+		} else if (character === ' ') {
+			options.push({ start: tokenStart, end: index });
 			tokenStart = undefined;
 		}
 	}
-	if (quote !== undefined) return undefined;
-	if (tokenStart !== undefined) options.push(nodeOptions.slice(tokenStart));
+	if (inDoubleQuotes) return undefined;
+	if (tokenStart !== undefined) options.push({ start: tokenStart, end: nodeOptions.length });
 	return options;
 }
 
@@ -619,7 +625,7 @@ export function isolatedBootstrapEnvironment(
 	const nodeOptions = isolatedEnvironment.NODE_OPTIONS;
 	if (nodeOptions === undefined) return isolatedEnvironment;
 
-	const options = splitNodeOptions(nodeOptions);
+	const options = scanNodeOptions(nodeOptions);
 	if (options === undefined) return isolatedEnvironment;
 	const loaderOptions: Record<string, true> = {
 		'--require': true,
@@ -628,22 +634,31 @@ export function isolatedBootstrapEnvironment(
 		'--loader': true,
 		'--experimental-loader': true,
 	};
-	const retainedOptions: string[] = [];
+	const removed = new Set<number>();
 	for (let index = 0; index < options.length; index += 1) {
 		const option = options[index]!;
-		const [name] = option.split('=', 1);
-		const loaderName = name.replaceAll('"', '').replaceAll("'", '').replaceAll('_', '-');
-		if (!(loaderName in loaderOptions)) {
-			retainedOptions.push(option);
-			continue;
-		}
-		if (!option.includes('=')) index += 1;
+		const value = nodeOptions.slice(option.start, option.end);
+		const [name] = value.split('=', 1);
+		const loaderName = name.replaceAll('"', '').replaceAll('_', '-');
+		if (!(loaderName in loaderOptions)) continue;
+		removed.add(index);
+		if (!value.includes('=') && index + 1 < options.length) removed.add(index + 1);
 	}
-	if (retainedOptions.length > 0) {
-		isolatedEnvironment.NODE_OPTIONS = retainedOptions.join(' ');
-	} else {
+	if (removed.size === 0) return isolatedEnvironment;
+	if (removed.size === options.length) {
 		delete isolatedEnvironment.NODE_OPTIONS;
+		return isolatedEnvironment;
 	}
+
+	let isolatedNodeOptions = '';
+	let cursor = 0;
+	for (let index = 0; index < options.length; index += 1) {
+		if (!removed.has(index)) continue;
+		const option = options[index]!;
+		isolatedNodeOptions += nodeOptions.slice(cursor, option.start);
+		cursor = option.end;
+	}
+	isolatedEnvironment.NODE_OPTIONS = isolatedNodeOptions + nodeOptions.slice(cursor);
 	return isolatedEnvironment;
 }
 

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -241,19 +241,42 @@ async function spawnSupervisedCommand(
 async function readPnpManifest(
 	pnpPath: string,
 	manifestPath: string,
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	pnpReaderLauncher = spawnSupervisedCommand
 ): Promise<PackageManifest> {
 	const cached = pnpManifests.get(manifestPath);
 	if (cached) return cached;
 	if (signal?.aborted) throw abortError(signal);
 
-	const temporaryRoot =
-		process.platform === 'win32'
-			? await mkdtemp(join(tmpdir(), 'every-astro-pnp-reader-'))
-			: undefined;
-	let child: ChildProcess;
+	let temporaryRoot: string | undefined;
+	let child: ChildProcess | undefined;
+	let closed: Promise<void> | undefined;
+	let abortCompletion: Promise<void> | undefined;
+	let rejectAbort!: (reason: unknown) => void;
+	const aborted = new Promise<never>((_resolveAbort, reject) => {
+		rejectAbort = reject;
+	});
+	const abort = () => {
+		if (!child || !closed) return;
+		abortCompletion ??= (async () => {
+			await terminateChildProcess(child);
+			await closed;
+		})();
+		void abortCompletion.then(
+			() => rejectAbort(abortError(signal!)),
+			(error: unknown) => rejectAbort(error)
+		);
+	};
+	if (signal) signal.addEventListener('abort', abort, { once: true });
+
+	let primaryError: unknown;
 	try {
-		child = await spawnSupervisedCommand(
+		temporaryRoot =
+			process.platform === 'win32'
+				? await mkdtemp(join(tmpdir(), 'every-astro-pnp-reader-'))
+				: undefined;
+		if (signal?.aborted) throw abortError(signal);
+		const reader = await pnpReaderLauncher(
 			temporaryRoot ?? '',
 			process.execPath,
 			[
@@ -271,43 +294,23 @@ async function readPnpManifest(
 				stdio: ['ignore', 'pipe', 'pipe'],
 			}
 		);
-	} catch (error) {
-		if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true });
-		throw error;
-	}
-	let output = '';
-	let errors = '';
-	child.stdout?.on('data', (chunk: Buffer) => {
-		output += chunk;
-	});
-	child.stderr?.on('data', (chunk: Buffer) => {
-		errors += chunk;
-	});
-	const closed = new Promise<void>((resolveClose) => {
-		child.once('close', () => resolveClose());
-	});
-	const completion = new Promise<number | null>((resolveExit, rejectExit) => {
-		child.once('error', rejectExit);
-		child.once('close', resolveExit);
-	});
-	let abortCompletion: Promise<void> | undefined;
-	let rejectAbort!: (reason: unknown) => void;
-	const aborted = new Promise<never>((_resolveAbort, reject) => {
-		rejectAbort = reject;
-	});
-	const abort = () => {
-		abortCompletion ??= (async () => {
-			await terminateChildProcess(child);
-			await closed;
-		})();
-		void abortCompletion.then(
-			() => rejectAbort(abortError(signal!)),
-			(error: unknown) => rejectAbort(error)
-		);
-	};
-	if (signal) signal.addEventListener('abort', abort, { once: true });
-	let primaryError: unknown;
-	try {
+		child = reader;
+		let output = '';
+		let errors = '';
+		reader.stdout?.on('data', (chunk: Buffer) => {
+			output += chunk;
+		});
+		reader.stderr?.on('data', (chunk: Buffer) => {
+			errors += chunk;
+		});
+		closed = new Promise<void>((resolveClose) => {
+			reader.once('close', () => resolveClose());
+		});
+		const completion = new Promise<number | null>((resolveExit, rejectExit) => {
+			reader.once('error', rejectExit);
+			reader.once('close', resolveExit);
+		});
+		if (signal?.aborted) abort();
 		const exitCode = await Promise.race([completion, aborted]);
 		if (signal?.aborted) {
 			await abortCompletion;
@@ -326,19 +329,32 @@ async function readPnpManifest(
 		throw error;
 	} finally {
 		signal?.removeEventListener('abort', abort);
-		let cleanupError: unknown;
+		const cleanupErrors: unknown[] = [];
 		try {
-			await terminateChildProcess(child);
-			await closed;
+			if (child) {
+				await terminateChildProcess(child);
+				await closed;
+			}
 		} catch (error) {
-			cleanupError = error;
+			cleanupErrors.push(error);
 		}
 		try {
 			if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true });
 		} catch (error) {
-			cleanupError ??= error;
+			cleanupErrors.push(error);
 		}
-		if (cleanupError && primaryError === undefined) throw cleanupError;
+		if (cleanupErrors.length > 0) {
+			const cleanupError =
+				cleanupErrors.length === 1
+					? cleanupErrors[0]!
+					: new AggregateError(cleanupErrors, 'Could not fully clean up the PnP manifest reader');
+			if (primaryError === undefined) throw cleanupError;
+			throw new AggregateError(
+				[primaryError, cleanupError],
+				'Could not read a PnP manifest and clean up its reader',
+				{ cause: primaryError }
+			);
+		}
 	}
 }
 
@@ -366,7 +382,8 @@ async function packageManifestFromPnp(
 	pnpPath: string | undefined,
 	packageName: string,
 	fromDirectory: string,
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	pnpReaderLauncher?: typeof spawnSupervisedCommand
 ): Promise<string | undefined> {
 	if (!pnpapi || !pnpPath) return undefined;
 	let packageRoot: string | null;
@@ -383,7 +400,7 @@ async function packageManifestFromPnp(
 	} catch (error: unknown) {
 		if ((error as NodeJS.ErrnoException).code !== 'ENOTDIR') throw error;
 	}
-	const manifest = await readPnpManifest(pnpPath, manifestPath, signal);
+	const manifest = await readPnpManifest(pnpPath, manifestPath, signal, pnpReaderLauncher);
 	return manifest.name === packageName ? manifestPath : undefined;
 }
 async function packageManifestFromEntry(
@@ -405,7 +422,8 @@ export async function resolveInstalledPackageManifest(
 	packageName: string,
 	fromDirectory: string,
 	pnpPath = nearestPnpPath(fromDirectory),
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	pnpReaderLauncher?: typeof spawnSupervisedCommand
 ): Promise<string | undefined> {
 	const pnpapi = loadPnpApi(pnpPath);
 	const requireFrom = createRequire(join(fromDirectory, 'package.json'));
@@ -414,7 +432,8 @@ export async function resolveInstalledPackageManifest(
 		pnpPath,
 		packageName,
 		fromDirectory,
-		signal
+		signal,
+		pnpReaderLauncher
 	);
 	if (pnpManifest) return pnpManifest;
 	try {

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -583,6 +583,34 @@ export async function linkBunPackage(projectRoot: string, link: PackageLink): Pr
 	return packagePath;
 }
 
+function splitNodeOptions(nodeOptions: string): string[] | undefined {
+	const options: string[] = [];
+	let tokenStart: number | undefined;
+	let quote: '"' | "'" | undefined;
+	for (let index = 0; index < nodeOptions.length; index += 1) {
+		const character = nodeOptions[index]!;
+		if (tokenStart === undefined) {
+			if (/\s/.test(character)) continue;
+			tokenStart = index;
+		}
+		if (quote !== undefined) {
+			if (quote === '"' && character === '\\' && index + 1 < nodeOptions.length) {
+				index += 1;
+			} else if (character === quote) {
+				quote = undefined;
+			}
+		} else if (character === '"' || character === "'") {
+			quote = character;
+		} else if (/\s/.test(character)) {
+			options.push(nodeOptions.slice(tokenStart, index));
+			tokenStart = undefined;
+		}
+	}
+	if (quote !== undefined) return undefined;
+	if (tokenStart !== undefined) options.push(nodeOptions.slice(tokenStart));
+	return options;
+}
+
 /** Remove consumer Node loader hooks from commands that run in the cloned repository. */
 export function isolatedBootstrapEnvironment(
 	environment: NodeJS.ProcessEnv = process.env
@@ -591,7 +619,8 @@ export function isolatedBootstrapEnvironment(
 	const nodeOptions = isolatedEnvironment.NODE_OPTIONS;
 	if (nodeOptions === undefined) return isolatedEnvironment;
 
-	const options = nodeOptions.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
+	const options = splitNodeOptions(nodeOptions);
+	if (options === undefined) return isolatedEnvironment;
 	const loaderOptions: Record<string, true> = {
 		'--require': true,
 		'-r': true,

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -608,7 +608,8 @@ export function isolatedBootstrapEnvironment(
 				? option.slice(1, -1)
 				: option;
 		const [name] = normalizedOption.split('=', 1);
-		if (!(name in loaderOptions)) {
+		const loaderName = name.replaceAll('_', '-');
+		if (!(loaderName in loaderOptions)) {
 			retainedOptions.push(option);
 			continue;
 		}

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -741,6 +741,11 @@ export function terminateChildProcess(
 }
 
 type ChildTerminator = (child: ChildProcess | undefined) => Promise<void>;
+type CommandSpawner = (
+	file: string,
+	args: string[],
+	options: NonNullable<Parameters<typeof spawn>[2]>
+) => ChildProcess | Promise<ChildProcess>;
 
 export class RuntimeSession implements BisectSession {
 	private activeChild: ChildProcess | undefined;
@@ -765,7 +770,8 @@ export class RuntimeSession implements BisectSession {
 		private readonly installedDependencies: ReadonlySet<string>,
 		private readonly latest: string,
 		private readonly signal: AbortSignal,
-		private readonly terminate: ChildTerminator = terminateChildProcess
+		private readonly terminate: ChildTerminator = terminateChildProcess,
+		private readonly commandSpawner?: CommandSpawner
 	) {}
 
 	public async latestRevision(): Promise<string> {
@@ -774,6 +780,16 @@ export class RuntimeSession implements BisectSession {
 
 	private async stopChild(child = this.activeChild): Promise<void> {
 		await this.terminate(child);
+	}
+
+	private async launchCommand(
+		file: string,
+		args: string[],
+		options: NonNullable<Parameters<typeof spawn>[2]>
+	): Promise<ChildProcess> {
+		return this.commandSpawner
+			? this.commandSpawner(file, args, options)
+			: this.spawnCommand(file, args, options);
 	}
 
 	private async spawnCommand(
@@ -810,7 +826,7 @@ export class RuntimeSession implements BisectSession {
 
 		let child: ChildProcess;
 		try {
-			child = await this.spawnCommand(file, args, {
+			child = await this.launchCommand(file, args, {
 				cwd,
 				env: options.env,
 				stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
@@ -1016,7 +1032,7 @@ export class RuntimeSession implements BisectSession {
 	}
 
 	public async runDevServerAndAsk(label: string): Promise<boolean> {
-		const child = await this.spawnCommand(this.manager, ['run', 'dev'], {
+		const child = await this.launchCommand(this.manager, ['run', 'dev'], {
 			cwd: this.projectRoot,
 			stdio: developmentServerStdio,
 			detached: process.platform !== 'win32',

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -318,10 +318,12 @@ export async function discoverAstroWorkspacePackages(
 	return manifests;
 }
 
-function abortError(signal: AbortSignal): Error {
-	return new Error(
+export function abortError(signal: AbortSignal): Error {
+	const error = new Error(
 		signal.reason ? `Operation aborted: ${String(signal.reason)}` : 'Operation aborted'
 	);
+	error.name = 'AbortError';
+	return error;
 }
 
 async function isYarnBerry(projectRoot: string): Promise<boolean> {
@@ -454,27 +456,64 @@ export async function linkBunPackage(projectRoot: string, link: PackageLink): Pr
 	return packagePath;
 }
 
-/** Remove the consumer's Node loader hooks from commands that run in the cloned repository. */
+/** Remove consumer Node loader hooks from commands that run in the cloned repository. */
 export function isolatedBootstrapEnvironment(
 	environment: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
 	const isolatedEnvironment = { ...environment };
-	delete isolatedEnvironment.NODE_OPTIONS;
+	const nodeOptions = isolatedEnvironment.NODE_OPTIONS;
+	if (nodeOptions === undefined) return isolatedEnvironment;
+
+	const options = nodeOptions.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
+	const loaderOptions: Record<string, true> = {
+		'--require': true,
+		'-r': true,
+		'--import': true,
+		'--loader': true,
+		'--experimental-loader': true,
+	};
+	const retainedOptions: string[] = [];
+	for (let index = 0; index < options.length; index += 1) {
+		const option = options[index]!;
+		const [name] = option.split('=', 1);
+		if (!(name in loaderOptions)) {
+			retainedOptions.push(option);
+			continue;
+		}
+		if (name === option) index += 1;
+	}
+	if (retainedOptions.length > 0) {
+		isolatedEnvironment.NODE_OPTIONS = retainedOptions.join(' ');
+	} else {
+		delete isolatedEnvironment.NODE_OPTIONS;
+	}
 	return isolatedEnvironment;
 }
 
-type SymlinkSnapshot = {
+export type DependencySymlinkSnapshot = {
 	path: string;
 	target: string;
+	type: 'dir' | 'junction';
 };
+
+export function dependencySymlinkType(platform = process.platform): 'dir' | 'junction' {
+	return platform === 'win32' ? 'junction' : 'dir';
+}
+
+/** Restore a dependency link exactly as it was before the bisect session. */
+export async function restoreDependencySymlink(snapshot: DependencySymlinkSnapshot): Promise<void> {
+	await rm(snapshot.path, { recursive: true, force: true });
+	await mkdir(dirname(snapshot.path), { recursive: true });
+	await symlink(snapshot.target, snapshot.path, snapshot.type);
+}
 
 async function snapshotDependencySymlinks(
 	projectRoot: string,
 	managerRoot: string,
 	packageNames: ReadonlySet<string>
-): Promise<SymlinkSnapshot[]> {
+): Promise<DependencySymlinkSnapshot[]> {
 	const requireFrom = createRequire(join(projectRoot, 'package.json'));
-	const snapshots = new Map<string, SymlinkSnapshot>();
+	const snapshots = new Map<string, DependencySymlinkSnapshot>();
 	for (const packageName of packageNames) {
 		if (packageName !== 'astro' && !packageName.startsWith('@astrojs/')) continue;
 		for (const nodeModules of requireFrom.resolve.paths(packageName) ?? []) {
@@ -486,6 +525,7 @@ async function snapshotDependencySymlinks(
 				snapshots.set(packagePath, {
 					path: packagePath,
 					target: await readlink(packagePath),
+					type: dependencySymlinkType(),
 				});
 			} catch (error: unknown) {
 				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
@@ -514,7 +554,7 @@ class RuntimeSession implements BisectSession {
 		private readonly originalProjectManifest: FileSnapshot,
 		private readonly managerLockPath: string,
 		private readonly originalManagerLock: FileSnapshot,
-		private readonly originalDependencySymlinks: readonly SymlinkSnapshot[],
+		private readonly originalDependencySymlinks: readonly DependencySymlinkSnapshot[],
 		private readonly installedDependencies: ReadonlySet<string>,
 		private readonly latest: string,
 		private readonly signal: AbortSignal
@@ -782,12 +822,6 @@ class RuntimeSession implements BisectSession {
 		this.linkedPackages.clear();
 	}
 
-	private async restoreDependencySymlink(snapshot: SymlinkSnapshot): Promise<void> {
-		await rm(snapshot.path, { recursive: true, force: true });
-		await mkdir(dirname(snapshot.path), { recursive: true });
-		await symlink(snapshot.target, snapshot.path);
-	}
-
 	private async restoreDependencies(): Promise<void> {
 		const failures: unknown[] = [];
 		const restore = async (operation: () => Promise<unknown>): Promise<void> => {
@@ -840,7 +874,7 @@ class RuntimeSession implements BisectSession {
 		}
 		await restore(() => restoreFile(this.managerLockPath, this.originalManagerLock));
 		for (const snapshot of this.originalDependencySymlinks) {
-			await restore(() => this.restoreDependencySymlink(snapshot));
+			await restore(() => restoreDependencySymlink(snapshot));
 		}
 		if (failures.length > 0) {
 			throw new AggregateError(failures, 'Could not fully restore project dependencies');
@@ -893,10 +927,40 @@ async function copyCorepackCli(temporaryRoot: string): Promise<string> {
 	return isolatedCli;
 }
 
+export function selectLatestAstroReleaseTag(tags: readonly string[], major: number): string {
+	const releases: { tag: string; minor: number; patch: number }[] = [];
+	for (const tag of tags) {
+		const match = /^astro@(\d+)\.(\d+)\.(\d+)$/.exec(tag.trim());
+		if (!match || Number(match[1]) !== major) continue;
+		releases.push({
+			tag: tag.trim(),
+			minor: Number(match[2]),
+			patch: Number(match[3]),
+		});
+	}
+	releases.sort(
+		(first, second) =>
+			second.minor - first.minor ||
+			second.patch - first.patch ||
+			first.tag.localeCompare(second.tag)
+	);
+	const latest = releases[0];
+	if (!latest) {
+		throw new Error(`Could not find a stable Astro ${major} release tag in the cloned repository`);
+	}
+	return latest.tag;
+}
+
+/** Git revision expression that resolves a release tag to the commit that bisect needs. */
+export function selectLatestAstroReleaseRevision(tags: readonly string[], major: number): string {
+	return `${selectLatestAstroReleaseTag(tags, major)}^{commit}`;
+}
+
 async function createRuntimeSession(
 	projectRoot: string,
 	managerInfo: DetectedPackageManager,
 	installedDependencies: ReadonlySet<string>,
+	installedAstroMajor: number,
 	signal: AbortSignal
 ): Promise<RuntimeSession> {
 	const managerRoot = managerInfo.root;
@@ -941,7 +1005,14 @@ async function createRuntimeSession(
 			signal
 		);
 		await bootstrap.execute(['git', 'clone', ASTRO_REPOSITORY, repositoryRoot], temporaryRoot);
-		const latest = await bootstrap.execute(['git', 'rev-parse', 'HEAD'], repositoryRoot, {
+		const tags = await bootstrap.execute(['git', 'tag', '--list'], repositoryRoot, {
+			capture: true,
+		});
+		const latestRevision = selectLatestAstroReleaseRevision(
+			tags.split(/\r?\n/),
+			installedAstroMajor
+		);
+		const latest = await bootstrap.execute(['git', 'rev-parse', latestRevision], repositoryRoot, {
 			capture: true,
 		});
 		const session = new RuntimeSession(
@@ -988,6 +1059,7 @@ export async function createRuntimeDependencies(
 				absoluteProjectRoot,
 				managerInfo,
 				installedDependencies,
+				major,
 				signal
 			);
 			return session;

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -1061,7 +1061,11 @@ export function isolatedBootstrapEnvironment(
 	return isolatedEnvironment;
 }
 
-async function windowsDirectorySymlinkType(path: string): Promise<'dir' | 'junction'> {
+async function windowsDirectorySymlinkType(
+	path: string,
+	signal?: AbortSignal
+): Promise<'dir' | 'junction'> {
+	if (signal?.aborted) throw abortError(signal);
 	const escapedPath = path.replaceAll("'", "''");
 	const child = spawn(
 		'powershell.exe',
@@ -1071,7 +1075,7 @@ async function windowsDirectorySymlinkType(path: string): Promise<'dir' | 'junct
 			'-Command',
 			`(Get-Item -LiteralPath '${escapedPath}' -Force).LinkType`,
 		],
-		{ stdio: ['ignore', 'pipe', 'pipe'] }
+		{ signal, stdio: ['ignore', 'pipe', 'pipe'] }
 	);
 	let output = '';
 	let errors = '';
@@ -1085,6 +1089,7 @@ async function windowsDirectorySymlinkType(path: string): Promise<'dir' | 'junct
 		child.once('error', rejectExit);
 		child.once('close', resolveExit);
 	});
+	if (signal?.aborted) throw abortError(signal);
 	if (exitCode !== 0) {
 		throw new Error(`Could not inspect Windows directory link ${path}: ${errors}`);
 	}
@@ -1114,22 +1119,31 @@ export async function restoreDependencySymlink(snapshot: DependencySymlinkSnapsh
 export async function snapshotDependencySymlinks(
 	projectRoot: string,
 	managerRoot: string,
-	packageNames: ReadonlySet<string>
+	packageNames: ReadonlySet<string>,
+	signal?: AbortSignal
 ): Promise<DependencySymlinkSnapshot[]> {
+	if (signal?.aborted) throw abortError(signal);
 	const requireFrom = createRequire(join(projectRoot, 'package.json'));
 	const snapshots = new Map<string, DependencySymlinkSnapshot>();
 	for (const packageName of packageNames) {
+		if (signal?.aborted) throw abortError(signal);
 		for (const nodeModules of requireFrom.resolve.paths(packageName) ?? []) {
+			if (signal?.aborted) throw abortError(signal);
 			const packagePath = join(nodeModules, packageName);
 			const relativePath = relative(managerRoot, packagePath);
 			if (relativePath.startsWith('..') || isAbsolute(relativePath)) continue;
 			try {
 				if (!(await lstat(packagePath)).isSymbolicLink()) continue;
+				if (signal?.aborted) throw abortError(signal);
+				const target = await readlink(packagePath);
+				if (signal?.aborted) throw abortError(signal);
 				snapshots.set(packagePath, {
 					path: packagePath,
-					target: await readlink(packagePath),
+					target,
 					type:
-						process.platform === 'win32' ? await windowsDirectorySymlinkType(packagePath) : 'dir',
+						process.platform === 'win32'
+							? await windowsDirectorySymlinkType(packagePath, signal)
+							: 'dir',
 				});
 			} catch (error: unknown) {
 				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
@@ -1853,7 +1867,7 @@ async function createRuntimeSession(
 		snapshotFile(join(managerRoot, 'package.json')),
 		snapshotFile(join(projectRoot, 'package.json')),
 		snapshotFile(managerLockPath),
-		snapshotDependencySymlinks(projectRoot, managerRoot, installedDependencies),
+		snapshotDependencySymlinks(projectRoot, managerRoot, installedDependencies, signal),
 	]);
 	if (!originalManagerLock.exists) {
 		throw new Error(

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -242,7 +242,8 @@ async function readPnpManifest(
 	pnpPath: string,
 	manifestPath: string,
 	signal?: AbortSignal,
-	pnpReaderLauncher = spawnSupervisedCommand
+	pnpReaderLauncher = spawnSupervisedCommand,
+	pnpReaderTerminator: ChildTerminator = terminateChildProcess
 ): Promise<PackageManifest> {
 	const cached = pnpManifests.get(manifestPath);
 	if (cached) return cached;
@@ -259,7 +260,7 @@ async function readPnpManifest(
 	const abort = () => {
 		if (!child || !closed) return;
 		abortCompletion ??= (async () => {
-			await terminateChildProcess(child);
+			await pnpReaderTerminator(child);
 			await closed;
 		})();
 		void abortCompletion.then(
@@ -269,6 +270,7 @@ async function readPnpManifest(
 	};
 	if (signal) signal.addEventListener('abort', abort, { once: true });
 
+	let manifest: PackageManifest | undefined;
 	let primaryError: unknown;
 	try {
 		temporaryRoot =
@@ -321,18 +323,14 @@ async function readPnpManifest(
 				`Could not read PnP manifest ${manifestPath} with Corepack Yarn (exit code ${exitCode}): ${errors}`
 			);
 		}
-		const manifest = JSON.parse(output) as PackageManifest;
-		pnpManifests.set(manifestPath, manifest);
-		return manifest;
+		manifest = JSON.parse(output) as PackageManifest;
 	} catch (error) {
 		primaryError = error;
-		throw error;
 	} finally {
-		signal?.removeEventListener('abort', abort);
 		const cleanupErrors: unknown[] = [];
 		try {
 			if (child) {
-				await terminateChildProcess(child);
+				await pnpReaderTerminator(child);
 				await closed;
 			}
 		} catch (error) {
@@ -343,6 +341,8 @@ async function readPnpManifest(
 		} catch (error) {
 			cleanupErrors.push(error);
 		}
+		if (signal?.aborted && primaryError === undefined) primaryError = abortError(signal);
+		signal?.removeEventListener('abort', abort);
 		if (cleanupErrors.length > 0) {
 			const cleanupError =
 				cleanupErrors.length === 1
@@ -356,6 +356,9 @@ async function readPnpManifest(
 			);
 		}
 	}
+	if (primaryError !== undefined) throw primaryError;
+	pnpManifests.set(manifestPath, manifest!);
+	return manifest!;
 }
 
 async function manifestAt(path: string, packageName: string): Promise<string | undefined> {
@@ -383,7 +386,8 @@ async function packageManifestFromPnp(
 	packageName: string,
 	fromDirectory: string,
 	signal?: AbortSignal,
-	pnpReaderLauncher?: typeof spawnSupervisedCommand
+	pnpReaderLauncher?: typeof spawnSupervisedCommand,
+	pnpReaderTerminator?: ChildTerminator
 ): Promise<string | undefined> {
 	if (!pnpapi || !pnpPath) return undefined;
 	let packageRoot: string | null;
@@ -400,7 +404,13 @@ async function packageManifestFromPnp(
 	} catch (error: unknown) {
 		if ((error as NodeJS.ErrnoException).code !== 'ENOTDIR') throw error;
 	}
-	const manifest = await readPnpManifest(pnpPath, manifestPath, signal, pnpReaderLauncher);
+	const manifest = await readPnpManifest(
+		pnpPath,
+		manifestPath,
+		signal,
+		pnpReaderLauncher,
+		pnpReaderTerminator
+	);
 	return manifest.name === packageName ? manifestPath : undefined;
 }
 async function packageManifestFromEntry(
@@ -423,7 +433,8 @@ export async function resolveInstalledPackageManifest(
 	fromDirectory: string,
 	pnpPath = nearestPnpPath(fromDirectory),
 	signal?: AbortSignal,
-	pnpReaderLauncher?: typeof spawnSupervisedCommand
+	pnpReaderLauncher?: typeof spawnSupervisedCommand,
+	pnpReaderTerminator?: ChildTerminator
 ): Promise<string | undefined> {
 	const pnpapi = loadPnpApi(pnpPath);
 	const requireFrom = createRequire(join(fromDirectory, 'package.json'));
@@ -433,7 +444,8 @@ export async function resolveInstalledPackageManifest(
 		packageName,
 		fromDirectory,
 		signal,
-		pnpReaderLauncher
+		pnpReaderLauncher,
+		pnpReaderTerminator
 	);
 	if (pnpManifest) return pnpManifest;
 	try {

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -85,6 +85,25 @@ export function windowsJobSupervisorCommand(controlFile: string): [string, ...st
 	];
 }
 
+const WINDOWS_CMD_META_CHARACTERS = /([()\][%!^"`<>&|;, *?])/g;
+const WINDOWS_CMD_SHIM = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i;
+
+/** Build the raw `/d /s /c` tail using cross-spawn's Windows escaping semantics. */
+export function windowsBatchCommandTail(file: string, args: readonly string[]): string {
+	const doubleEscapeMetaCharacters = WINDOWS_CMD_SHIM.test(file);
+	const command = file.replaceAll('/', '\\').replace(WINDOWS_CMD_META_CHARACTERS, '^$1');
+	const escapedArguments = args.map((argument) => {
+		let escaped = `${argument}`;
+		escaped = escaped.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"');
+		escaped = escaped.replace(/(?=(\\+?)?)\1$/, '$1$1');
+		escaped = `"${escaped}"`.replace(WINDOWS_CMD_META_CHARACTERS, '^$1');
+		return doubleEscapeMetaCharacters
+			? escaped.replace(WINDOWS_CMD_META_CHARACTERS, '^$1')
+			: escaped;
+	});
+	return `/d /s /c "${[command, ...escapedArguments].join(' ')}"`;
+}
+
 /** Development servers must not consume the terminal input reserved for the bisect prompt. */
 export const developmentServerStdio: ['ignore', 'inherit', 'inherit'] = [
 	'ignore',

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -674,6 +674,7 @@ export async function collectInstalledDependencyNames(
 	const visitedManifests = new Set<string>();
 
 	while (pending.length > 0) {
+		if (signal?.aborted) throw abortError(signal);
 		const dependency = pending.pop()!;
 		const manifestPath = await resolveInstalledPackageManifest(
 			dependency.name,
@@ -1889,21 +1890,38 @@ export async function createRuntimeDependencies(
 	signal: AbortSignal
 ): Promise<EveryAstroDependencies> {
 	const absoluteProjectRoot = resolve(projectRoot);
-	const [managerInfo, major, installedDependencies] = await Promise.all([
-		detectPackageManagerInfo(absoluteProjectRoot),
-		installedAstroMajor(absoluteProjectRoot, signal),
-		collectInstalledDependencyNames(absoluteProjectRoot, signal),
-	]);
+	const initializationController = new AbortController();
+	const initializationSignal = AbortSignal.any([signal, initializationController.signal]);
+	const managerInfo = detectPackageManagerInfo(absoluteProjectRoot);
+	const major = installedAstroMajor(absoluteProjectRoot, initializationSignal);
+	const installedDependencies = collectInstalledDependencyNames(
+		absoluteProjectRoot,
+		initializationSignal
+	);
+	let resolvedManagerInfo: DetectedPackageManager;
+	let resolvedMajor: number;
+	let resolvedInstalledDependencies: Set<string>;
+	try {
+		[resolvedManagerInfo, resolvedMajor, resolvedInstalledDependencies] = await Promise.all([
+			managerInfo,
+			major,
+			installedDependencies,
+		]);
+	} catch (error) {
+		initializationController.abort(error);
+		await Promise.allSettled([managerInfo, major, installedDependencies]);
+		throw error;
+	}
 	let session: Promise<RuntimeSession> | undefined;
 	return {
 		signal,
-		installedAstroMajor: () => Promise.resolve(major),
+		installedAstroMajor: () => Promise.resolve(resolvedMajor),
 		createSession: () => {
 			session ??= createRuntimeSession(
 				absoluteProjectRoot,
-				managerInfo,
-				installedDependencies,
-				major,
+				resolvedManagerInfo,
+				resolvedInstalledDependencies,
+				resolvedMajor,
 				signal
 			);
 			return session;

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -532,10 +532,9 @@ async function installedNodeModulesPackagePath(
 
 /** Replace a Bun-installed package with a local package without invoking Bun's registry linker. */
 export async function linkBunPackage(projectRoot: string, link: PackageLink): Promise<string> {
-	const packagePath = await installedNodeModulesPackagePath(projectRoot, link.name);
-	if (!packagePath) {
-		throw new Error(`Could not find the Bun-installed ${link.name} package from ${projectRoot}`);
-	}
+	const packagePath =
+		(await installedNodeModulesPackagePath(projectRoot, link.name)) ??
+		join(projectRoot, 'node_modules', link.name);
 	await rm(packagePath, { recursive: true, force: true });
 	await mkdir(dirname(packagePath), { recursive: true });
 	await symlink(link.path, packagePath, process.platform === 'win32' ? 'junction' : 'dir');
@@ -630,6 +629,11 @@ export function terminateChildProcess(
 	if (!child) return Promise.resolve();
 	const termination = childTerminations.get(child);
 	if (termination) return termination;
+	if (child.exitCode !== null || child.signalCode !== null) {
+		const stopped = Promise.resolve();
+		childTerminations.set(child, stopped);
+		return stopped;
+	}
 	const pid = child.pid;
 	if (!pid) return Promise.resolve();
 
@@ -640,7 +644,7 @@ export function terminateChildProcess(
 				taskkill.once('error', rejectExit);
 				taskkill.once('close', resolveExit);
 			});
-			if (exitCode !== 0) {
+			if (exitCode !== 0 && child.exitCode === null && child.signalCode === null) {
 				throw new Error(`taskkill failed while terminating process ${pid} (exit code ${exitCode})`);
 			}
 			return;
@@ -687,6 +691,7 @@ export function terminateChildProcess(
 
 class RuntimeSession implements BisectSession {
 	private activeChild: ChildProcess | undefined;
+	private bisectActive = false;
 	private readonly bunLinkTargets = new Map<string, string>();
 	private readonly linkedPackages = new Map<string, string>();
 	private closing: Promise<void> | undefined;
@@ -1250,9 +1255,6 @@ async function createRuntimeSession(
 			latest.trim(),
 			signal
 		);
-		signal.addEventListener('abort', () => void session.close().catch(() => undefined), {
-			once: true,
-		});
 		return session;
 	} catch (error) {
 		try {
@@ -1281,6 +1283,7 @@ export async function createRuntimeDependencies(
 	]);
 	let session: Promise<RuntimeSession> | undefined;
 	return {
+		signal,
 		installedAstroMajor: () => Promise.resolve(major),
 		createSession: () => {
 			session ??= createRuntimeSession(

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -411,11 +411,7 @@ export function packageLinkCommands(
 			return [
 				{
 					command: yarnBerry
-						? [
-								'yarn',
-								'add',
-								...links.map(({ name, path }) => `${name}@portal:${path}`),
-							]
+						? ['yarn', 'add', ...links.map(({ name, path }) => `${name}@portal:${path}`)]
 						: [
 								'yarn',
 								'add',

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -214,13 +214,20 @@ function loadPnpApi(pnpPath: string | undefined): PnpApi | undefined {
 	return pnpapi;
 }
 
+type PnpReaderLaunchObserver = (child: ChildProcess) => void;
+
 async function spawnSupervisedCommand(
 	temporaryRoot: string,
 	file: string,
 	args: string[],
-	options: NonNullable<Parameters<typeof spawn>[2]>
+	options: NonNullable<Parameters<typeof spawn>[2]>,
+	observeLaunch?: PnpReaderLaunchObserver
 ): Promise<ChildProcess> {
-	if (process.platform !== 'win32') return spawn(file, args, options);
+	if (process.platform !== 'win32') {
+		const child = spawn(file, args, options);
+		observeLaunch?.(child);
+		return child;
+	}
 
 	const controlFile = join(temporaryRoot, `command-${randomUUID()}.json`);
 	await writeFile(controlFile, JSON.stringify({ file, args }));
@@ -235,7 +242,18 @@ async function spawnSupervisedCommand(
 	const cleanControlFile = () => void rm(controlFile, { force: true }).catch(() => undefined);
 	child.once('error', cleanControlFile);
 	child.once('close', cleanControlFile);
+	observeLaunch?.(child);
 	return child;
+}
+
+async function createPnpReaderTemporaryRoot(): Promise<string | undefined> {
+	return process.platform === 'win32'
+		? mkdtemp(join(tmpdir(), 'every-astro-pnp-reader-'))
+		: undefined;
+}
+
+async function removePnpReaderTemporaryRoot(temporaryRoot: string): Promise<void> {
+	await rm(temporaryRoot, { recursive: true, force: true });
 }
 
 async function readPnpManifest(
@@ -243,7 +261,9 @@ async function readPnpManifest(
 	manifestPath: string,
 	signal?: AbortSignal,
 	pnpReaderLauncher = spawnSupervisedCommand,
-	pnpReaderTerminator: ChildTerminator = terminateChildProcess
+	pnpReaderTerminator: ChildTerminator = terminateChildProcess,
+	pnpReaderTemporaryRootCreator = createPnpReaderTemporaryRoot,
+	pnpReaderTemporaryRootRemover = removePnpReaderTemporaryRoot
 ): Promise<PackageManifest> {
 	const cached = pnpManifests.get(manifestPath);
 	if (cached) return cached;
@@ -252,6 +272,34 @@ async function readPnpManifest(
 	let temporaryRoot: string | undefined;
 	let child: ChildProcess | undefined;
 	let closed: Promise<void> | undefined;
+	let completion: Promise<number | null> | undefined;
+	let output = '';
+	let errors = '';
+	let streamError: unknown;
+	const observeReader = (reader: ChildProcess) => {
+		if (child) return;
+		child = reader;
+		reader.stdout?.on('data', (chunk: Buffer) => {
+			output += chunk;
+		});
+		reader.stdout?.once('error', (error) => {
+			streamError ??= error;
+		});
+		reader.stderr?.on('data', (chunk: Buffer) => {
+			errors += chunk;
+		});
+		reader.stderr?.once('error', (error) => {
+			streamError ??= error;
+		});
+		closed = new Promise<void>((resolveClose) => {
+			reader.once('close', () => resolveClose());
+		});
+		completion = new Promise<number | null>((resolveExit, rejectExit) => {
+			reader.once('error', rejectExit);
+			reader.once('exit', resolveExit);
+		});
+		void completion.catch(() => undefined);
+	};
 	let abortCompletion: Promise<void> | undefined;
 	let rejectAbort!: (reason: unknown) => void;
 	const aborted = new Promise<never>((_resolveAbort, reject) => {
@@ -270,16 +318,11 @@ async function readPnpManifest(
 	};
 	if (signal) signal.addEventListener('abort', abort, { once: true });
 
-	let output = '';
-	let errors = '';
-	let streamError: unknown;
 	let exitCode: number | null | undefined;
+	let manifest: PackageManifest | undefined;
 	let primaryError: unknown;
 	try {
-		temporaryRoot =
-			process.platform === 'win32'
-				? await mkdtemp(join(tmpdir(), 'every-astro-pnp-reader-'))
-				: undefined;
+		temporaryRoot = await pnpReaderTemporaryRootCreator();
 		if (signal?.aborted) throw abortError(signal);
 		const reader = await pnpReaderLauncher(
 			temporaryRoot ?? '',
@@ -297,30 +340,12 @@ async function readPnpManifest(
 				detached: process.platform !== 'win32',
 				env: isolatedBootstrapEnvironment(),
 				stdio: ['ignore', 'pipe', 'pipe'],
-			}
+			},
+			observeReader
 		);
-		child = reader;
-		reader.stdout?.on('data', (chunk: Buffer) => {
-			output += chunk;
-		});
-		reader.stdout?.once('error', (error) => {
-			streamError ??= error;
-		});
-		reader.stderr?.on('data', (chunk: Buffer) => {
-			errors += chunk;
-		});
-		reader.stderr?.once('error', (error) => {
-			streamError ??= error;
-		});
-		closed = new Promise<void>((resolveClose) => {
-			reader.once('close', () => resolveClose());
-		});
-		const completion = new Promise<number | null>((resolveExit, rejectExit) => {
-			reader.once('error', rejectExit);
-			reader.once('exit', resolveExit);
-		});
+		observeReader(reader);
 		if (signal?.aborted) abort();
-		exitCode = await Promise.race([completion, aborted]);
+		exitCode = await Promise.race([completion!, aborted]);
 		if (signal?.aborted) {
 			await abortCompletion;
 			throw abortError(signal);
@@ -329,16 +354,38 @@ async function readPnpManifest(
 		primaryError = error;
 	} finally {
 		const cleanupErrors: unknown[] = [];
+		let terminated = true;
 		try {
-			if (child) {
-				await pnpReaderTerminator(child);
-				await closed;
-			}
+			if (child) await pnpReaderTerminator(child);
 		} catch (error) {
+			terminated = false;
 			cleanupErrors.push(error);
 		}
+		if (child && terminated) {
+			try {
+				await closed;
+			} catch (error) {
+				cleanupErrors.push(error);
+			}
+		}
+		if (signal?.aborted && primaryError === undefined) primaryError = abortError(signal);
+		if (primaryError === undefined) {
+			if (streamError) {
+				primaryError = streamError;
+			} else if (exitCode !== 0) {
+				primaryError = new Error(
+					`Could not read PnP manifest ${manifestPath} with Corepack Yarn (exit code ${exitCode}): ${errors}`
+				);
+			} else {
+				try {
+					manifest = JSON.parse(output) as PackageManifest;
+				} catch (error) {
+					primaryError = error;
+				}
+			}
+		}
 		try {
-			if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true });
+			if (temporaryRoot) await pnpReaderTemporaryRootRemover(temporaryRoot);
 		} catch (error) {
 			cleanupErrors.push(error);
 		}
@@ -358,15 +405,8 @@ async function readPnpManifest(
 		}
 	}
 	if (primaryError !== undefined) throw primaryError;
-	if (streamError) throw streamError;
-	if (exitCode !== 0) {
-		throw new Error(
-			`Could not read PnP manifest ${manifestPath} with Corepack Yarn (exit code ${exitCode}): ${errors}`
-		);
-	}
-	const manifest = JSON.parse(output) as PackageManifest;
-	pnpManifests.set(manifestPath, manifest);
-	return manifest;
+	pnpManifests.set(manifestPath, manifest!);
+	return manifest!;
 }
 
 async function manifestAt(path: string, packageName: string): Promise<string | undefined> {
@@ -395,7 +435,9 @@ async function packageManifestFromPnp(
 	fromDirectory: string,
 	signal?: AbortSignal,
 	pnpReaderLauncher?: typeof spawnSupervisedCommand,
-	pnpReaderTerminator?: ChildTerminator
+	pnpReaderTerminator?: ChildTerminator,
+	pnpReaderTemporaryRootCreator?: typeof createPnpReaderTemporaryRoot,
+	pnpReaderTemporaryRootRemover?: typeof removePnpReaderTemporaryRoot
 ): Promise<string | undefined> {
 	if (!pnpapi || !pnpPath) return undefined;
 	let packageRoot: string | null;
@@ -417,7 +459,9 @@ async function packageManifestFromPnp(
 		manifestPath,
 		signal,
 		pnpReaderLauncher,
-		pnpReaderTerminator
+		pnpReaderTerminator,
+		pnpReaderTemporaryRootCreator,
+		pnpReaderTemporaryRootRemover
 	);
 	return manifest.name === packageName ? manifestPath : undefined;
 }
@@ -442,7 +486,9 @@ export async function resolveInstalledPackageManifest(
 	pnpPath = nearestPnpPath(fromDirectory),
 	signal?: AbortSignal,
 	pnpReaderLauncher?: typeof spawnSupervisedCommand,
-	pnpReaderTerminator?: ChildTerminator
+	pnpReaderTerminator?: ChildTerminator,
+	pnpReaderTemporaryRootCreator?: typeof createPnpReaderTemporaryRoot,
+	pnpReaderTemporaryRootRemover?: typeof removePnpReaderTemporaryRoot
 ): Promise<string | undefined> {
 	const pnpapi = loadPnpApi(pnpPath);
 	const requireFrom = createRequire(join(fromDirectory, 'package.json'));
@@ -453,7 +499,9 @@ export async function resolveInstalledPackageManifest(
 		fromDirectory,
 		signal,
 		pnpReaderLauncher,
-		pnpReaderTerminator
+		pnpReaderTerminator,
+		pnpReaderTemporaryRootCreator,
+		pnpReaderTemporaryRootRemover
 	);
 	if (pnpManifest) return pnpManifest;
 	try {

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -1,0 +1,834 @@
+import type { ChildProcess, spawn as NodeSpawn } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import type { BisectSession, EveryAstroDependencies } from './workflow.js';
+
+const ASTRO_REPOSITORY = 'https://github.com/withastro/astro.git';
+const PACKAGE_MANAGERS = ['pnpm', 'yarn', 'bun', 'npm'] as const;
+
+const runtimeRequire = createRequire(import.meta.url);
+const spawn = runtimeRequire('cross-spawn') as typeof NodeSpawn;
+const corepackCli = join(
+	dirname(runtimeRequire.resolve('corepack/package.json')),
+	'dist',
+	'corepack.js'
+);
+
+export type PackageManager = (typeof PACKAGE_MANAGERS)[number];
+
+type PackageManifest = {
+	name?: string;
+	version?: string;
+	private?: boolean;
+	packageManager?: string;
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+};
+
+type CommandOptions = {
+	capture?: boolean;
+	ignoreAbort?: boolean;
+};
+
+class CommandError extends Error {
+	public constructor(
+		readonly command: readonly string[],
+		readonly cwd: string,
+		readonly exitCode: number | null,
+		readonly output: string
+	) {
+		super(
+			`Command failed (${exitCode ?? 'signal'}): ${command.join(' ')}\nWorking directory: ${cwd}${output ? `\n${output}` : ''}`
+		);
+		this.name = 'CommandError';
+	}
+}
+
+function commandText(command: readonly string[]): string {
+	return command.map((part) => JSON.stringify(part)).join(' ');
+}
+
+async function readManifest(path: string): Promise<PackageManifest> {
+	return JSON.parse(await readFile(path, 'utf8')) as PackageManifest;
+}
+
+async function existingManifest(path: string): Promise<PackageManifest | undefined> {
+	try {
+		return await readManifest(path);
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+		throw error;
+	}
+}
+
+type DetectedPackageManager = {
+	manager: PackageManager;
+	root: string;
+};
+
+const LOCKFILES: readonly [string, PackageManager][] = [
+	['pnpm-lock.yaml', 'pnpm'],
+	['yarn.lock', 'yarn'],
+	['bun.lockb', 'bun'],
+	['bun.lock', 'bun'],
+	['package-lock.json', 'npm'],
+	['npm-shrinkwrap.json', 'npm'],
+];
+
+async function detectPackageManagerInfo(projectRoot: string): Promise<DetectedPackageManager> {
+	let directory = resolve(projectRoot);
+	while (true) {
+		const manifest = await existingManifest(join(directory, 'package.json'));
+		const configured = manifest?.packageManager?.split('@', 1)[0];
+		if (configured && (PACKAGE_MANAGERS as readonly string[]).includes(configured)) {
+			return { manager: configured as PackageManager, root: directory };
+		}
+		for (const [lockfile, manager] of LOCKFILES) {
+			if (existsSync(join(directory, lockfile))) return { manager, root: directory };
+		}
+		const parent = dirname(directory);
+		if (parent === directory) return { manager: 'npm', root: resolve(projectRoot) };
+		directory = parent;
+	}
+}
+
+/** Detect the nearest package manager declaration or conventional lockfile. */
+export async function detectPackageManager(projectRoot: string): Promise<PackageManager> {
+	return (await detectPackageManagerInfo(projectRoot)).manager;
+}
+
+type PnpApi = {
+	resolveToUnqualified: (request: string, issuer: string) => string | null;
+	setup?: () => void;
+};
+
+const pnpApis = new Map<string, PnpApi>();
+
+function nearestPnpPath(fromDirectory: string): string | undefined {
+	let directory = resolve(fromDirectory);
+	while (true) {
+		const pnpPath = join(directory, '.pnp.cjs');
+		if (existsSync(pnpPath)) return pnpPath;
+		const parent = dirname(directory);
+		if (parent === directory) return undefined;
+		directory = parent;
+	}
+}
+
+function loadPnpApi(pnpPath: string | undefined): PnpApi | undefined {
+	if (!pnpPath) return undefined;
+	const cached = pnpApis.get(pnpPath);
+	if (cached) return cached;
+
+	const pnpapi = runtimeRequire(pnpPath) as PnpApi;
+	pnpapi.setup?.();
+	pnpApis.set(pnpPath, pnpapi);
+	return pnpapi;
+}
+
+async function manifestAt(path: string, packageName: string): Promise<string | undefined> {
+	const manifest = await existingManifest(path);
+	return manifest?.name === packageName ? path : undefined;
+}
+
+async function packageManifestFromNodeModules(
+	requireFrom: NodeJS.Require,
+	packageName: string
+): Promise<string | undefined> {
+	for (const nodeModules of requireFrom.resolve.paths(packageName) ?? []) {
+		const manifestPath = await manifestAt(
+			join(nodeModules, packageName, 'package.json'),
+			packageName
+		);
+		if (manifestPath) return realpath(manifestPath);
+	}
+	return undefined;
+}
+
+async function packageManifestFromPnp(
+	pnpapi: PnpApi | undefined,
+	packageName: string,
+	fromDirectory: string
+): Promise<string | undefined> {
+	if (!pnpapi) return undefined;
+	try {
+		const packageRoot = pnpapi.resolveToUnqualified(
+			packageName,
+			join(fromDirectory, 'package.json')
+		);
+		return packageRoot
+			? await manifestAt(join(packageRoot, 'package.json'), packageName)
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+async function packageManifestFromEntry(
+	entry: string,
+	packageName: string
+): Promise<string | undefined> {
+	let directory = dirname(entry);
+	while (directory !== dirname(directory)) {
+		const manifestPath = join(directory, 'package.json');
+		const manifest = await existingManifest(manifestPath);
+		if (manifest?.name === packageName) return manifestPath;
+		directory = dirname(directory);
+	}
+	return undefined;
+}
+
+/** Resolve a package manifest even when its package.json subpath is not exported. */
+export async function resolveInstalledPackageManifest(
+	packageName: string,
+	fromDirectory: string,
+	pnpPath = nearestPnpPath(fromDirectory)
+): Promise<string | undefined> {
+	const pnpapi = loadPnpApi(pnpPath);
+	const requireFrom = createRequire(join(fromDirectory, 'package.json'));
+	const pnpManifest = await packageManifestFromPnp(pnpapi, packageName, fromDirectory);
+	if (pnpManifest) return pnpManifest;
+	try {
+		const manifestPath = await manifestAt(
+			requireFrom.resolve(`${packageName}/package.json`),
+			packageName
+		);
+		if (manifestPath) return manifestPath;
+	} catch {
+		// Package manifests are commonly hidden by package export maps.
+	}
+	const nodeModulesManifest = await packageManifestFromNodeModules(requireFrom, packageName);
+	if (nodeModulesManifest) return nodeModulesManifest;
+	try {
+		return await packageManifestFromEntry(requireFrom.resolve(packageName), packageName);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Find the locally installed Astro version and return its parsed major number. */
+export async function installedAstroMajor(projectRoot: string): Promise<number> {
+	const manifestPath = await resolveInstalledPackageManifest('astro', projectRoot);
+	if (!manifestPath) {
+		throw new Error(`Could not resolve the installed Astro package from ${projectRoot}`);
+	}
+	const version = (await readManifest(manifestPath)).version;
+	const major = version ? Number.parseInt(version.split('.', 1)[0]!, 10) : Number.NaN;
+	if (!Number.isSafeInteger(major) || major < 0) {
+		throw new Error(
+			`Installed Astro at ${manifestPath} has an invalid version: ${version ?? 'missing'}`
+		);
+	}
+	return major;
+}
+
+function packageDependencies(manifest: PackageManifest, includeDevDependencies = false): string[] {
+	return Object.keys({
+		...manifest.dependencies,
+		...manifest.optionalDependencies,
+		...manifest.peerDependencies,
+		...(includeDevDependencies ? manifest.devDependencies : undefined),
+	});
+}
+
+/**
+ * Walk manifests resolved from the project rather than assuming a node_modules layout.
+ * This works with scoped names, pnpm's virtual store, and package export maps.
+ */
+export async function collectInstalledDependencyNames(projectRoot: string): Promise<Set<string>> {
+	const rootManifest = await readManifest(join(projectRoot, 'package.json'));
+	const pnpPath = nearestPnpPath(projectRoot);
+	loadPnpApi(pnpPath);
+	const pending = packageDependencies(rootManifest, true).map((name) => ({
+		name,
+		from: projectRoot,
+	}));
+	const names = new Set<string>();
+	const visitedManifests = new Set<string>();
+
+	while (pending.length > 0) {
+		const dependency = pending.pop()!;
+		const manifestPath = await resolveInstalledPackageManifest(
+			dependency.name,
+			dependency.from,
+			pnpPath
+		);
+		if (!manifestPath || visitedManifests.has(manifestPath)) continue;
+
+		visitedManifests.add(manifestPath);
+		const manifest = await readManifest(manifestPath);
+		if (!manifest.name) continue;
+		names.add(manifest.name);
+		for (const name of packageDependencies(manifest)) {
+			pending.push({ name, from: dirname(manifestPath) });
+		}
+	}
+
+	return names;
+}
+
+async function walkPackageManifests(
+	directory: string,
+	manifests: Map<string, string>
+): Promise<void> {
+	const entries = await readdir(directory, { withFileTypes: true });
+	for (const entry of entries) {
+		if (entry.name === '.git' || entry.name === 'node_modules') continue;
+		const path = join(directory, entry.name);
+		if (entry.isDirectory()) {
+			await walkPackageManifests(path, manifests);
+			continue;
+		}
+		if (!entry.isFile() || entry.name !== 'package.json') continue;
+
+		const manifest = await existingManifest(path);
+		if (!manifest?.name || manifest.private) continue;
+		if (manifest.name === 'astro' || manifest.name.startsWith('@astrojs/')) {
+			manifests.set(manifest.name, dirname(path));
+		}
+	}
+}
+
+/** Discover public Astro workspace packages without a glob dependency. */
+export async function discoverAstroWorkspacePackages(
+	repositoryRoot: string
+): Promise<Map<string, string>> {
+	const manifests = new Map<string, string>();
+	await walkPackageManifests(repositoryRoot, manifests);
+	return manifests;
+}
+
+function abortError(signal: AbortSignal): Error {
+	return new Error(
+		signal.reason ? `Operation aborted: ${String(signal.reason)}` : 'Operation aborted'
+	);
+}
+
+async function isYarnBerry(projectRoot: string): Promise<boolean> {
+	if (existsSync(join(projectRoot, '.yarnrc.yml'))) return true;
+	const manager = (await readManifest(join(projectRoot, 'package.json'))).packageManager;
+	const version = manager?.match(/^yarn@(\d+)/)?.[1];
+	return version !== undefined && Number(version) >= 2;
+}
+
+type FileSnapshot = {
+	exists: boolean;
+	content: Buffer;
+};
+
+async function snapshotFile(path: string): Promise<FileSnapshot> {
+	try {
+		return { exists: true, content: await readFile(path) };
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT')
+			return { exists: false, content: Buffer.alloc(0) };
+		throw error;
+	}
+}
+
+async function restoreFile(path: string, snapshot: FileSnapshot): Promise<void> {
+	if (snapshot.exists) {
+		await writeFile(path, snapshot.content);
+	} else {
+		await rm(path, { force: true });
+	}
+}
+
+function managerLockfile(manager: PackageManager, projectRoot: string): string {
+	switch (manager) {
+		case 'pnpm':
+			return join(projectRoot, 'pnpm-lock.yaml');
+		case 'yarn':
+			return join(projectRoot, 'yarn.lock');
+		case 'bun':
+			return join(
+				projectRoot,
+				existsSync(join(projectRoot, 'bun.lockb')) ? 'bun.lockb' : 'bun.lock'
+			);
+		case 'npm':
+			return join(
+				projectRoot,
+				existsSync(join(projectRoot, 'npm-shrinkwrap.json'))
+					? 'npm-shrinkwrap.json'
+					: 'package-lock.json'
+			);
+	}
+}
+
+class RuntimeSession implements BisectSession {
+	private activeChild: ChildProcess | undefined;
+	private readonly linkedPackages = new Map<string, string>();
+	private bisectActive = false;
+	private closing: Promise<void> | undefined;
+
+	public constructor(
+		private readonly projectRoot: string,
+		private readonly managerRoot: string,
+		private readonly repositoryRoot: string,
+		private readonly temporaryRoot: string,
+		private readonly manager: PackageManager,
+		private readonly yarnBerry: boolean,
+		private readonly originalManagerManifest: FileSnapshot,
+		private readonly managerLockPath: string,
+		private readonly originalManagerLock: FileSnapshot,
+		private readonly installedDependencies: ReadonlySet<string>,
+		private readonly latest: string,
+		private readonly signal: AbortSignal
+	) {}
+
+	public async latestRevision(): Promise<string> {
+		return this.latest;
+	}
+
+	private async stopChild(child = this.activeChild): Promise<void> {
+		const pid = child?.pid;
+		if (!child || !pid || child.exitCode !== null) return;
+		const signal = (name: NodeJS.Signals): void => {
+			try {
+				if (process.platform === 'win32') {
+					spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+				} else {
+					process.kill(-pid, name);
+				}
+			} catch {
+				try {
+					child.kill(name);
+				} catch {
+					// The child may have already exited.
+				}
+			}
+		};
+		const closed = once(child, 'close')
+			.then(() => true)
+			.catch(() => true);
+		signal('SIGTERM');
+		if (!(await Promise.race([closed, delay(5_000).then(() => false)]))) {
+			signal('SIGKILL');
+			await Promise.race([closed, delay(5_000)]).catch(() => undefined);
+		}
+	}
+
+	public async execute(
+		command: readonly string[],
+		cwd: string,
+		options: CommandOptions = {}
+	): Promise<string> {
+		if (this.signal.aborted && !options.ignoreAbort) throw abortError(this.signal);
+		const [file, ...args] = command;
+		if (!file) throw new Error('Cannot run an empty command');
+
+		let child: ChildProcess;
+		try {
+			child = spawn(file, args, {
+				cwd,
+				stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+				detached: process.platform !== 'win32',
+			});
+		} catch (error) {
+			throw new Error(`Could not start ${commandText(command)} in ${cwd}: ${String(error)}`);
+		}
+		this.activeChild = child;
+		let output = '';
+		if (options.capture) {
+			child.stdout?.on('data', (chunk: Buffer) => {
+				output += chunk.toString();
+			});
+			child.stderr?.on('data', (chunk: Buffer) => {
+				output += chunk.toString();
+			});
+		}
+
+		let exitCode: number | null;
+		try {
+			exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
+				const abort = () => void this.stopChild(child);
+				if (!options.ignoreAbort) this.signal.addEventListener('abort', abort, { once: true });
+				child.once('error', (error) => {
+					if (!options.ignoreAbort) this.signal.removeEventListener('abort', abort);
+					rejectExit(
+						new Error(`Could not run ${commandText(command)} in ${cwd}: ${String(error)}`)
+					);
+				});
+				child.once('close', (code) => {
+					if (!options.ignoreAbort) this.signal.removeEventListener('abort', abort);
+					resolveExit(code);
+				});
+			});
+		} finally {
+			if (this.activeChild === child) this.activeChild = undefined;
+		}
+		if (this.signal.aborted && !options.ignoreAbort) throw abortError(this.signal);
+		if (exitCode !== 0) {
+			throw new CommandError(command, cwd, exitCode, output);
+		}
+		return output;
+	}
+
+	private async linkPackages(packages: ReadonlyMap<string, string>): Promise<void> {
+		const links = [...this.installedDependencies].flatMap((name) => {
+			const path = packages.get(name);
+			return path ? [{ name, path }] : [];
+		});
+		if (!links.some(({ name }) => name === 'astro')) {
+			throw new Error(
+				'Astro is not available in both the installed dependencies and this revision'
+			);
+		}
+
+		for (const { name, path } of links) this.linkedPackages.set(name, path);
+		switch (this.manager) {
+			case 'npm':
+				await this.execute(
+					['npm', 'install', '--no-save', '--package-lock=false', ...links.map(({ path }) => path)],
+					this.projectRoot
+				);
+				break;
+			case 'bun':
+				for (const { path } of links) await this.execute(['bun', 'link'], path);
+				await this.execute(
+					['bun', 'link', ...links.map(({ name }) => name), '--no-save'],
+					this.projectRoot
+				);
+				break;
+			case 'yarn':
+				if (this.yarnBerry) {
+					await this.execute(['yarn', 'link', ...links.map(({ path }) => path)], this.projectRoot);
+				} else {
+					for (const { path } of links) await this.execute(['yarn', 'link'], path);
+					await this.execute(['yarn', 'link', ...links.map(({ name }) => name)], this.projectRoot);
+				}
+				break;
+			case 'pnpm':
+				for (const { path } of links) await this.execute(['pnpm', 'link', path], this.projectRoot);
+		}
+	}
+
+	private async restorePreviousLinks(): Promise<void> {
+		if (this.linkedPackages.size === 0) return;
+
+		const failures: unknown[] = [];
+		try {
+			await this.unlinkPackages();
+		} catch (error) {
+			failures.push(error);
+		}
+		try {
+			await this.restoreDependencies();
+			this.linkedPackages.clear();
+		} catch (error) {
+			failures.push(error);
+		}
+
+		if (failures.length > 0) {
+			throw new AggregateError(failures, 'Could not restore dependencies between revisions');
+		}
+	}
+
+	public async prepareRevision(revision: string): Promise<void> {
+		await this.restorePreviousLinks();
+		await this.execute(['git', 'checkout', '--force', revision], this.repositoryRoot);
+		await this.execute(['git', 'clean', '-fdx'], this.repositoryRoot);
+		await this.execute(
+			[process.execPath, corepackCli, 'pnpm', 'install', '--frozen-lockfile'],
+			this.repositoryRoot
+		);
+		await this.execute(
+			[process.execPath, corepackCli, 'pnpm', 'run', 'build'],
+			this.repositoryRoot
+		);
+		await this.linkPackages(await discoverAstroWorkspacePackages(this.repositoryRoot));
+	}
+
+	private async prompt(label: string): Promise<boolean> {
+		const readline = createInterface({ input: process.stdin, output: process.stdout });
+		try {
+			while (true) {
+				const response = (
+					await readline.question(`${label}: is the bug present? [y/n] `, { signal: this.signal })
+				)
+					.trim()
+					.toLowerCase();
+				if (response === 'y' || response === 'yes') return true;
+				if (response === 'n' || response === 'no') return false;
+				console.error('Please answer y or n.');
+			}
+		} finally {
+			readline.close();
+		}
+	}
+
+	public async runDevServerAndAsk(label: string): Promise<boolean> {
+		if (this.signal.aborted) throw abortError(this.signal);
+		const child = spawn(this.manager, ['run', 'dev'], {
+			cwd: this.projectRoot,
+			stdio: 'inherit',
+			detached: process.platform !== 'win32',
+		});
+		this.activeChild = child;
+		const earlyExit = new Promise<never>((_, reject) => {
+			child.once('error', (error) =>
+				reject(
+					new Error(
+						`Could not start ${this.manager} run dev in ${this.projectRoot}: ${String(error)}`
+					)
+				)
+			);
+			child.once('exit', (code) =>
+				reject(new CommandError([this.manager, 'run', 'dev'], this.projectRoot, code, ''))
+			);
+		});
+		try {
+			await Promise.race([delay(100, undefined, { signal: this.signal }), earlyExit]);
+			return await Promise.race([this.prompt(label), earlyExit]);
+		} finally {
+			await this.stopChild(child);
+			if (this.activeChild === child) this.activeChild = undefined;
+		}
+	}
+
+	public async startBisect(good: string, bad: string): Promise<void> {
+		await this.execute(['git', 'bisect', 'start', bad, good], this.repositoryRoot);
+		this.bisectActive = true;
+	}
+
+	public async currentRevision(): Promise<string> {
+		return (
+			await this.execute(['git', 'rev-parse', 'HEAD'], this.repositoryRoot, { capture: true })
+		).trim();
+	}
+
+	public async markCurrent(isBad: boolean): Promise<string | undefined> {
+		const output = await this.execute(
+			['git', 'bisect', isBad ? 'bad' : 'good'],
+			this.repositoryRoot,
+			{ capture: true }
+		);
+		return output.match(/\b([0-9a-f]{40}) is the first bad commit\b/i)?.[1];
+	}
+
+	private async unlinkPackages(): Promise<void> {
+		const failures: unknown[] = [];
+		const unlink = async (command: string[], cwd: string): Promise<void> => {
+			try {
+				await this.execute(command, cwd, { ignoreAbort: true });
+			} catch (error) {
+				failures.push(error);
+			}
+		};
+		for (const [name, path] of this.linkedPackages) {
+			switch (this.manager) {
+				case 'npm':
+					break;
+				case 'bun':
+					await unlink(['bun', 'unlink', name], this.projectRoot);
+					await unlink(['bun', 'unlink'], path);
+					break;
+				case 'yarn':
+					await unlink(['yarn', 'unlink', name], this.projectRoot);
+					if (!this.yarnBerry) await unlink(['yarn', 'unlink'], path);
+					break;
+				case 'pnpm':
+					await unlink(['pnpm', 'unlink', name], this.projectRoot);
+			}
+		}
+		if (failures.length > 0) {
+			throw new AggregateError(failures, 'Could not unlink all Astro packages');
+		}
+		this.linkedPackages.clear();
+	}
+
+	private async restoreDependencies(): Promise<void> {
+		const failures: unknown[] = [];
+		const restore = async (operation: () => Promise<unknown>): Promise<void> => {
+			try {
+				await operation();
+			} catch (error) {
+				failures.push(error);
+			}
+		};
+		await restore(() =>
+			restoreFile(join(this.managerRoot, 'package.json'), this.originalManagerManifest)
+		);
+		await restore(() => restoreFile(this.managerLockPath, this.originalManagerLock));
+		switch (this.manager) {
+			case 'pnpm':
+				await restore(() =>
+					this.execute(
+						[
+							'pnpm',
+							'install',
+							...(this.originalManagerLock.exists
+								? ['--frozen-lockfile']
+								: ['--no-frozen-lockfile', '--lockfile=false']),
+						],
+						this.managerRoot,
+						{ ignoreAbort: true }
+					)
+				);
+				break;
+			case 'yarn':
+				await restore(() =>
+					this.execute(
+						[
+							'yarn',
+							'install',
+							...(this.originalManagerLock.exists
+								? [this.yarnBerry ? '--immutable' : '--frozen-lockfile']
+								: this.yarnBerry
+									? ['--no-immutable']
+									: []),
+						],
+						this.managerRoot,
+						{ ignoreAbort: true }
+					)
+				);
+				break;
+			case 'bun':
+				await restore(() =>
+					this.execute(
+						[
+							'bun',
+							'install',
+							...(this.originalManagerLock.exists ? ['--frozen-lockfile'] : ['--no-save']),
+						],
+						this.managerRoot,
+						{ ignoreAbort: true }
+					)
+				);
+				break;
+			case 'npm':
+				await restore(() =>
+					this.execute(
+						[
+							'npm',
+							this.originalManagerLock.exists ? 'ci' : 'install',
+							...(this.originalManagerLock.exists ? [] : ['--no-package-lock']),
+						],
+						this.managerRoot,
+						{ ignoreAbort: true }
+					)
+				);
+		}
+		await restore(() => restoreFile(this.managerLockPath, this.originalManagerLock));
+		if (failures.length > 0) {
+			throw new AggregateError(failures, 'Could not fully restore project dependencies');
+		}
+	}
+	public async close(): Promise<void> {
+		if (this.closing) return this.closing;
+		this.closing = (async () => {
+			const failures: unknown[] = [];
+			const cleanup = async (operation: () => Promise<unknown>): Promise<void> => {
+				try {
+					await operation();
+				} catch (error) {
+					failures.push(error);
+				}
+			};
+			await cleanup(() => this.stopChild());
+			await cleanup(() => this.unlinkPackages());
+			await cleanup(() => this.restoreDependencies());
+			if (this.bisectActive) {
+				await cleanup(() =>
+					this.execute(['git', 'bisect', 'reset'], this.repositoryRoot, { ignoreAbort: true })
+				);
+			}
+			await cleanup(() => rm(this.temporaryRoot, { recursive: true, force: true }));
+			if (failures.length > 0) {
+				throw new AggregateError(failures, 'every-astro cleanup failed');
+			}
+		})();
+		return this.closing;
+	}
+}
+
+async function createRuntimeSession(
+	projectRoot: string,
+	managerInfo: DetectedPackageManager,
+	installedDependencies: ReadonlySet<string>,
+	signal: AbortSignal
+): Promise<RuntimeSession> {
+	const temporaryRoot = await mkdtemp(join(tmpdir(), 'every-astro-'));
+	const repositoryRoot = join(temporaryRoot, 'astro');
+	const managerRoot = managerInfo.root;
+	const managerLockPath = managerLockfile(managerInfo.manager, managerRoot);
+	const [yarnBerry, originalManagerManifest, originalManagerLock] = await Promise.all([
+		isYarnBerry(managerRoot),
+		snapshotFile(join(managerRoot, 'package.json')),
+		snapshotFile(managerLockPath),
+	]);
+	try {
+		const bootstrap = new RuntimeSession(
+			projectRoot,
+			managerRoot,
+			repositoryRoot,
+			temporaryRoot,
+			managerInfo.manager,
+			yarnBerry,
+			originalManagerManifest,
+			managerLockPath,
+			originalManagerLock,
+			new Set(),
+			'',
+			signal
+		);
+		await bootstrap.execute(['git', 'clone', ASTRO_REPOSITORY, repositoryRoot], temporaryRoot);
+		const latest = await bootstrap.execute(['git', 'rev-parse', 'HEAD'], repositoryRoot, {
+			capture: true,
+		});
+		const session = new RuntimeSession(
+			projectRoot,
+			managerRoot,
+			repositoryRoot,
+			temporaryRoot,
+			managerInfo.manager,
+			yarnBerry,
+			originalManagerManifest,
+			managerLockPath,
+			originalManagerLock,
+			installedDependencies,
+			latest.trim(),
+			signal
+		);
+		signal.addEventListener('abort', () => void session.close(), { once: true });
+		return session;
+	} catch (error) {
+		await rm(temporaryRoot, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+/** Build the runtime implementation consumed by the pure workflow. */
+export async function createRuntimeDependencies(
+	projectRoot: string,
+	signal: AbortSignal
+): Promise<EveryAstroDependencies> {
+	const absoluteProjectRoot = resolve(projectRoot);
+	const [managerInfo, major, installedDependencies] = await Promise.all([
+		detectPackageManagerInfo(absoluteProjectRoot),
+		installedAstroMajor(absoluteProjectRoot),
+		collectInstalledDependencyNames(absoluteProjectRoot),
+	]);
+	let session: Promise<RuntimeSession> | undefined;
+	return {
+		installedAstroMajor: () => Promise.resolve(major),
+		createSession: () => {
+			session ??= createRuntimeSession(
+				absoluteProjectRoot,
+				managerInfo,
+				installedDependencies,
+				signal
+			);
+			return session;
+		},
+		log: (message) => console.log(message),
+	};
+}

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -1849,9 +1849,10 @@ async function createRuntimeSession(
 	}
 	const temporaryRoot = await mkdtemp(join(tmpdir(), 'every-astro-'));
 	const repositoryRoot = join(temporaryRoot, 'astro');
+	let bootstrap: RuntimeSession | undefined;
 	try {
 		const isolatedCorepackCli = await copyCorepackCli(temporaryRoot);
-		const bootstrap = new RuntimeSession(
+		bootstrap = new RuntimeSession(
 			projectRoot,
 			managerRoot,
 			repositoryRoot,
@@ -1904,12 +1905,28 @@ async function createRuntimeSession(
 		);
 		return session;
 	} catch (error) {
+		const cleanupErrors: unknown[] = [];
+		try {
+			await bootstrap?.close();
+		} catch (cleanupError) {
+			cleanupErrors.push(cleanupError);
+		}
 		try {
 			await rm(temporaryRoot, { recursive: true, force: true });
 		} catch (cleanupError) {
+			cleanupErrors.push(cleanupError);
+		}
+		if (cleanupErrors.length > 0) {
+			const cleanupError =
+				cleanupErrors.length === 1
+					? cleanupErrors[0]!
+					: new AggregateError(
+							cleanupErrors,
+							'Could not fully clean up the every-astro bootstrap session'
+						);
 			throw new AggregateError(
 				[error, cleanupError],
-				'Could not create every-astro runtime session and remove its temporary directory',
+				'Could not create every-astro runtime session and clean up its bootstrap session',
 				{ cause: error }
 			);
 		}

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -483,7 +483,11 @@ async function readPnpManifest(
 ): Promise<PackageManifest> {
 	if (signal?.aborted) throw abortError(signal);
 	const cached = pnpManifests.get(manifestPath);
-	if (cached) return cached;
+	if (cached) {
+		await Promise.resolve();
+		if (signal?.aborted) throw abortError(signal);
+		return cached;
+	}
 
 	let read = pnpManifestReads.get(manifestPath);
 	if (read?.controller.signal.aborted) {
@@ -627,7 +631,11 @@ export async function resolveInstalledPackageManifest(
 		pnpReaderTemporaryRootCreator,
 		pnpReaderTemporaryRootRemover
 	);
-	if (pnpManifest) return pnpManifest;
+	if (pnpManifest) {
+		await Promise.resolve();
+		if (signal?.aborted) throw abortError(signal);
+		return pnpManifest;
+	}
 	try {
 		const manifestPath = await manifestAt(
 			requireFrom.resolve(`${packageName}/package.json`),
@@ -1313,6 +1321,11 @@ export class RuntimeSession implements BisectSession {
 		await this.terminate(child);
 	}
 
+	/** Stop only bootstrap-owned work after session construction fails. */
+	public async closeBootstrap(): Promise<void> {
+		await this.stopChild();
+	}
+
 	private async launchCommand(
 		file: string,
 		args: string[],
@@ -1907,7 +1920,7 @@ async function createRuntimeSession(
 	} catch (error) {
 		const cleanupErrors: unknown[] = [];
 		try {
-			await bootstrap?.close();
+			await bootstrap?.closeBootstrap();
 		} catch (cleanupError) {
 			cleanupErrors.push(cleanupError);
 		}

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -629,7 +629,7 @@ export function terminateChildProcess(
 	if (!child) return Promise.resolve();
 	const termination = childTerminations.get(child);
 	if (termination) return termination;
-	if (child.exitCode !== null || child.signalCode !== null) {
+	if (platform === 'win32' && (child.exitCode !== null || child.signalCode !== null)) {
 		const stopped = Promise.resolve();
 		childTerminations.set(child, stopped);
 		return stopped;

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -663,10 +663,16 @@ async function snapshotDependencySymlinks(
 
 const childTerminations = new WeakMap<ChildProcess, Promise<void>>();
 
+type TaskkillLauncher = (pid: number) => ChildProcess;
+
+const launchTaskkill: TaskkillLauncher = (pid) =>
+	spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+
 export function terminateChildProcess(
 	child: ChildProcess | undefined,
 	platform = process.platform,
-	gracePeriod = 5_000
+	gracePeriod = 5_000,
+	taskkillLauncher: TaskkillLauncher = launchTaskkill
 ): Promise<void> {
 	if (!child) return Promise.resolve();
 	const termination = childTerminations.get(child);
@@ -681,7 +687,7 @@ export function terminateChildProcess(
 
 	const promise = (async () => {
 		if (platform === 'win32') {
-			const taskkill = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+			const taskkill = taskkillLauncher(pid);
 			const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
 				taskkill.once('error', rejectExit);
 				taskkill.once('close', resolveExit);

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -1024,14 +1024,14 @@ export function isolatedBootstrapEnvironment(
 }
 
 async function windowsDirectorySymlinkType(path: string): Promise<'dir' | 'junction'> {
+	const escapedPath = path.replaceAll("'", "''");
 	const child = spawn(
 		'powershell.exe',
 		[
 			'-NoProfile',
 			'-NonInteractive',
 			'-Command',
-			'(Get-Item -LiteralPath $args[0] -Force).LinkType',
-			path,
+			`(Get-Item -LiteralPath '${escapedPath}' -Force).LinkType`,
 		],
 		{ stdio: ['ignore', 'pipe', 'pipe'] }
 	);
@@ -1169,7 +1169,10 @@ export function terminateChildProcess(
 		return close;
 	}
 	const pid = child.pid;
-	if (!pid) return platform === 'win32' ? close : Promise.resolve();
+	if (!pid) {
+		forgetChildClose(child);
+		return Promise.resolve();
+	}
 
 	const promise = (async () => {
 		if (platform === 'win32') {

--- a/packages/every-astro/src/runtime.ts
+++ b/packages/every-astro/src/runtime.ts
@@ -1,10 +1,21 @@
 import type { ChildProcess, spawn as NodeSpawn } from 'node:child_process';
 import { once } from 'node:events';
 import { existsSync } from 'node:fs';
-import { mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import {
+	lstat,
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	readlink,
+	realpath,
+	rm,
+	symlink,
+	writeFile,
+} from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { setTimeout as delay } from 'node:timers/promises';
 
@@ -363,6 +374,98 @@ function managerLockfile(manager: PackageManager, projectRoot: string): string {
 	}
 }
 
+type PackageLink = {
+	name: string;
+	path: string;
+};
+
+type PackageLinkCommand = {
+	command: string[];
+	cwd: string;
+};
+
+export function packageLinkCommands(
+	manager: PackageManager,
+	yarnBerry: boolean,
+	projectRoot: string,
+	links: readonly PackageLink[]
+): PackageLinkCommand[] {
+	switch (manager) {
+		case 'npm':
+			return [
+				{
+					command: [
+						'npm',
+						'install',
+						'--no-save',
+						'--package-lock=false',
+						...links.map(({ path }) => path),
+					],
+					cwd: projectRoot,
+				},
+			];
+		case 'bun':
+			return [
+				{
+					command: ['bun', 'add', '--no-save', ...links.map(({ path }) => path)],
+					cwd: projectRoot,
+				},
+			];
+		case 'yarn':
+			return [
+				{
+					command: yarnBerry
+						? ['yarn', 'link', ...links.map(({ path }) => path)]
+						: [
+								'yarn',
+								'add',
+								'--pure-lockfile',
+								'--ignore-workspace-root-check',
+								...links.map(({ path }) => `link:${path}`),
+							],
+					cwd: projectRoot,
+				},
+			];
+		case 'pnpm':
+			return links.map(({ path }) => ({
+				command: ['pnpm', 'link', path],
+				cwd: projectRoot,
+			}));
+	}
+}
+
+type SymlinkSnapshot = {
+	path: string;
+	target: string;
+};
+
+async function snapshotDependencySymlinks(
+	projectRoot: string,
+	managerRoot: string,
+	packageNames: ReadonlySet<string>
+): Promise<SymlinkSnapshot[]> {
+	const requireFrom = createRequire(join(projectRoot, 'package.json'));
+	const snapshots = new Map<string, SymlinkSnapshot>();
+	for (const packageName of packageNames) {
+		if (packageName !== 'astro' && !packageName.startsWith('@astrojs/')) continue;
+		for (const nodeModules of requireFrom.resolve.paths(packageName) ?? []) {
+			const packagePath = join(nodeModules, packageName);
+			const relativePath = relative(managerRoot, packagePath);
+			if (relativePath.startsWith('..') || isAbsolute(relativePath)) continue;
+			try {
+				if (!(await lstat(packagePath)).isSymbolicLink()) continue;
+				snapshots.set(packagePath, {
+					path: packagePath,
+					target: await readlink(packagePath),
+				});
+			} catch (error: unknown) {
+				if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+			}
+		}
+	}
+	return [...snapshots.values()];
+}
+
 class RuntimeSession implements BisectSession {
 	private activeChild: ChildProcess | undefined;
 	private readonly linkedPackages = new Map<string, string>();
@@ -377,8 +480,10 @@ class RuntimeSession implements BisectSession {
 		private readonly manager: PackageManager,
 		private readonly yarnBerry: boolean,
 		private readonly originalManagerManifest: FileSnapshot,
+		private readonly originalProjectManifest: FileSnapshot,
 		private readonly managerLockPath: string,
 		private readonly originalManagerLock: FileSnapshot,
+		private readonly originalDependencySymlinks: readonly SymlinkSnapshot[],
 		private readonly installedDependencies: ReadonlySet<string>,
 		private readonly latest: string,
 		private readonly signal: AbortSignal
@@ -484,30 +589,13 @@ class RuntimeSession implements BisectSession {
 		}
 
 		for (const { name, path } of links) this.linkedPackages.set(name, path);
-		switch (this.manager) {
-			case 'npm':
-				await this.execute(
-					['npm', 'install', '--no-save', '--package-lock=false', ...links.map(({ path }) => path)],
-					this.projectRoot
-				);
-				break;
-			case 'bun':
-				for (const { path } of links) await this.execute(['bun', 'link'], path);
-				await this.execute(
-					['bun', 'link', ...links.map(({ name }) => name), '--no-save'],
-					this.projectRoot
-				);
-				break;
-			case 'yarn':
-				if (this.yarnBerry) {
-					await this.execute(['yarn', 'link', ...links.map(({ path }) => path)], this.projectRoot);
-				} else {
-					for (const { path } of links) await this.execute(['yarn', 'link'], path);
-					await this.execute(['yarn', 'link', ...links.map(({ name }) => name)], this.projectRoot);
-				}
-				break;
-			case 'pnpm':
-				for (const { path } of links) await this.execute(['pnpm', 'link', path], this.projectRoot);
+		for (const { command, cwd } of packageLinkCommands(
+			this.manager,
+			this.yarnBerry,
+			this.projectRoot,
+			links
+		)) {
+			await this.execute(command, cwd);
 		}
 	}
 
@@ -626,14 +714,10 @@ class RuntimeSession implements BisectSession {
 		for (const [name, path] of this.linkedPackages) {
 			switch (this.manager) {
 				case 'npm':
-					break;
 				case 'bun':
-					await unlink(['bun', 'unlink', name], this.projectRoot);
-					await unlink(['bun', 'unlink'], path);
 					break;
 				case 'yarn':
-					await unlink(['yarn', 'unlink', name], this.projectRoot);
-					if (!this.yarnBerry) await unlink(['yarn', 'unlink'], path);
+					if (this.yarnBerry) await unlink(['yarn', 'unlink', name], this.projectRoot);
 					break;
 				case 'pnpm':
 					await unlink(['pnpm', 'unlink', name], this.projectRoot);
@@ -643,6 +727,12 @@ class RuntimeSession implements BisectSession {
 			throw new AggregateError(failures, 'Could not unlink all Astro packages');
 		}
 		this.linkedPackages.clear();
+	}
+
+	private async restoreDependencySymlink(snapshot: SymlinkSnapshot): Promise<void> {
+		await rm(snapshot.path, { recursive: true, force: true });
+		await mkdir(dirname(snapshot.path), { recursive: true });
+		await symlink(snapshot.target, snapshot.path);
 	}
 
 	private async restoreDependencies(): Promise<void> {
@@ -657,21 +747,18 @@ class RuntimeSession implements BisectSession {
 		await restore(() =>
 			restoreFile(join(this.managerRoot, 'package.json'), this.originalManagerManifest)
 		);
+		if (this.projectRoot !== this.managerRoot) {
+			await restore(() =>
+				restoreFile(join(this.projectRoot, 'package.json'), this.originalProjectManifest)
+			);
+		}
 		await restore(() => restoreFile(this.managerLockPath, this.originalManagerLock));
 		switch (this.manager) {
 			case 'pnpm':
 				await restore(() =>
-					this.execute(
-						[
-							'pnpm',
-							'install',
-							...(this.originalManagerLock.exists
-								? ['--frozen-lockfile']
-								: ['--no-frozen-lockfile', '--lockfile=false']),
-						],
-						this.managerRoot,
-						{ ignoreAbort: true }
-					)
+					this.execute(['pnpm', 'install', '--frozen-lockfile'], this.managerRoot, {
+						ignoreAbort: true,
+					})
 				);
 				break;
 			case 'yarn':
@@ -680,11 +767,8 @@ class RuntimeSession implements BisectSession {
 						[
 							'yarn',
 							'install',
-							...(this.originalManagerLock.exists
-								? [this.yarnBerry ? '--immutable' : '--frozen-lockfile']
-								: this.yarnBerry
-									? ['--no-immutable']
-									: []),
+							this.yarnBerry ? '--immutable' : '--frozen-lockfile',
+							...(!this.yarnBerry ? ['--force'] : []),
 						],
 						this.managerRoot,
 						{ ignoreAbort: true }
@@ -693,31 +777,18 @@ class RuntimeSession implements BisectSession {
 				break;
 			case 'bun':
 				await restore(() =>
-					this.execute(
-						[
-							'bun',
-							'install',
-							...(this.originalManagerLock.exists ? ['--frozen-lockfile'] : ['--no-save']),
-						],
-						this.managerRoot,
-						{ ignoreAbort: true }
-					)
+					this.execute(['bun', 'install', '--frozen-lockfile', '--force'], this.managerRoot, {
+						ignoreAbort: true,
+					})
 				);
 				break;
 			case 'npm':
-				await restore(() =>
-					this.execute(
-						[
-							'npm',
-							this.originalManagerLock.exists ? 'ci' : 'install',
-							...(this.originalManagerLock.exists ? [] : ['--no-package-lock']),
-						],
-						this.managerRoot,
-						{ ignoreAbort: true }
-					)
-				);
+				await restore(() => this.execute(['npm', 'ci'], this.managerRoot, { ignoreAbort: true }));
 		}
 		await restore(() => restoreFile(this.managerLockPath, this.originalManagerLock));
+		for (const snapshot of this.originalDependencySymlinks) {
+			await restore(() => this.restoreDependencySymlink(snapshot));
+		}
 		if (failures.length > 0) {
 			throw new AggregateError(failures, 'Could not fully restore project dependencies');
 		}
@@ -756,15 +827,28 @@ async function createRuntimeSession(
 	installedDependencies: ReadonlySet<string>,
 	signal: AbortSignal
 ): Promise<RuntimeSession> {
-	const temporaryRoot = await mkdtemp(join(tmpdir(), 'every-astro-'));
-	const repositoryRoot = join(temporaryRoot, 'astro');
 	const managerRoot = managerInfo.root;
 	const managerLockPath = managerLockfile(managerInfo.manager, managerRoot);
-	const [yarnBerry, originalManagerManifest, originalManagerLock] = await Promise.all([
+	const [
+		yarnBerry,
+		originalManagerManifest,
+		originalProjectManifest,
+		originalManagerLock,
+		originalDependencySymlinks,
+	] = await Promise.all([
 		isYarnBerry(managerRoot),
 		snapshotFile(join(managerRoot, 'package.json')),
+		snapshotFile(join(projectRoot, 'package.json')),
 		snapshotFile(managerLockPath),
+		snapshotDependencySymlinks(projectRoot, managerRoot, installedDependencies),
 	]);
+	if (!originalManagerLock.exists) {
+		throw new Error(
+			`every-astro requires a ${managerInfo.manager} lockfile to restore the exact dependency tree`
+		);
+	}
+	const temporaryRoot = await mkdtemp(join(tmpdir(), 'every-astro-'));
+	const repositoryRoot = join(temporaryRoot, 'astro');
 	try {
 		const bootstrap = new RuntimeSession(
 			projectRoot,
@@ -774,8 +858,10 @@ async function createRuntimeSession(
 			managerInfo.manager,
 			yarnBerry,
 			originalManagerManifest,
+			originalProjectManifest,
 			managerLockPath,
 			originalManagerLock,
+			originalDependencySymlinks,
 			new Set(),
 			'',
 			signal
@@ -792,8 +878,10 @@ async function createRuntimeSession(
 			managerInfo.manager,
 			yarnBerry,
 			originalManagerManifest,
+			originalProjectManifest,
 			managerLockPath,
 			originalManagerLock,
+			originalDependencySymlinks,
 			installedDependencies,
 			latest.trim(),
 			signal

--- a/packages/every-astro/src/windows-job-supervisor.ps1
+++ b/packages/every-astro/src/windows-job-supervisor.ps1
@@ -193,6 +193,56 @@ public static class EveryAstroWindowsJob {
         return commandLine;
     }
 
+    private static string EscapeMetaCharacters(string value) {
+        const string metaCharacters = "()[]%!^\"`<>&|;, *?";
+        var escaped = new StringBuilder();
+        foreach (var character in value) {
+            if (metaCharacters.IndexOf(character) >= 0) escaped.Append('^');
+            escaped.Append(character);
+        }
+        return escaped.ToString();
+    }
+
+    private static string EscapeBatchArgument(string value, bool doubleEscapeMetaCharacters) {
+        var escaped = new StringBuilder();
+        for (var index = 0; index < value.Length;) {
+            if (value[index] != '\\') {
+                escaped.Append(value[index++]);
+                continue;
+            }
+            var next = index;
+            while (next < value.Length && value[next] == '\\') next++;
+            var slashCount = next - index;
+            if (next == value.Length) {
+                escaped.Append('\\', slashCount * 2);
+            } else if (value[next] == '"') {
+                escaped.Append('\\', slashCount * 2 + 1);
+                escaped.Append('"');
+                next++;
+            } else {
+                escaped.Append('\\', slashCount);
+            }
+            index = next;
+        }
+        var quoted = EscapeMetaCharacters("\"" + escaped + "\"");
+        return doubleEscapeMetaCharacters ? EscapeMetaCharacters(quoted) : quoted;
+    }
+
+    private static bool IsCmdShim(string file) {
+        var normalized = file.Replace('/', '\\');
+        return normalized.IndexOf("\\node_modules\\.bin\\", StringComparison.OrdinalIgnoreCase) >= 0 &&
+            normalized.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static StringBuilder BuildCmdCommandLine(string cmd, string batchFile, string[] arguments) {
+        var shellCommand = new StringBuilder(EscapeMetaCharacters(batchFile.Replace('/', '\\')));
+        var doubleEscapeMetaCharacters = IsCmdShim(batchFile);
+        foreach (var argument in arguments) {
+            shellCommand.Append(' ').Append(EscapeBatchArgument(argument, doubleEscapeMetaCharacters));
+        }
+        return new StringBuilder(Quote(cmd)).Append(" /d /s /c \"").Append(shellCommand).Append("\"");
+    }
+
     private static void Drain(IntPtr job) {
         while (true) {
             JOBOBJECT_BASIC_ACCOUNTING_INFORMATION accounting;
@@ -231,10 +281,10 @@ public static class EveryAstroWindowsJob {
             );
 
             var targetFile = file;
-            var targetArguments = arguments;
+            var commandLine = BuildCommandLine(file, arguments);
             if (file.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase) || file.EndsWith(".bat", StringComparison.OrdinalIgnoreCase)) {
                 targetFile = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
-                targetArguments = new[] { "/d", "/s", "/c", BuildCommandLine(file, arguments).ToString() };
+                commandLine = BuildCmdCommandLine(targetFile, file, arguments);
             }
 
             var startupInfo = new STARTUPINFO();
@@ -246,7 +296,7 @@ public static class EveryAstroWindowsJob {
             Check(
                 CreateProcess(
                     targetFile,
-                    BuildCommandLine(targetFile, targetArguments),
+                    commandLine,
                     IntPtr.Zero,
                     IntPtr.Zero,
                     true,

--- a/packages/every-astro/src/windows-job-supervisor.ps1
+++ b/packages/every-astro/src/windows-job-supervisor.ps1
@@ -6,7 +6,7 @@ param(
 $ErrorActionPreference = 'Stop'
 
 try {
-	$control = Get-Content -LiteralPath $ControlFile -Raw | ConvertFrom-Json
+	$control = Get-Content -LiteralPath $ControlFile -Encoding UTF8 -Raw | ConvertFrom-Json
 	$command = Get-Command -Name $control.file -CommandType Application -ErrorAction Stop | Select-Object -First 1
 	$targetFile = $command.Path
 	$targetArguments = [string[]] @($control.args)

--- a/packages/every-astro/src/windows-job-supervisor.ps1
+++ b/packages/every-astro/src/windows-job-supervisor.ps1
@@ -1,0 +1,293 @@
+param(
+	[Parameter(Mandatory = $true)]
+	[string] $ControlFile
+)
+
+$ErrorActionPreference = 'Stop'
+
+try {
+	$control = Get-Content -LiteralPath $ControlFile -Raw | ConvertFrom-Json
+	$command = Get-Command -Name $control.file -CommandType Application -ErrorAction Stop | Select-Object -First 1
+	$targetFile = $command.Path
+	$targetArguments = [string[]] @($control.args)
+
+	Add-Type @'
+using System;
+using System.ComponentModel;
+using System.Text;
+using System.Threading;
+using System.Runtime.InteropServices;
+
+public static class EveryAstroWindowsJob {
+    private const uint CREATE_SUSPENDED = 0x00000004;
+    private const uint STARTF_USESTDHANDLES = 0x00000100;
+    private const int STD_INPUT_HANDLE = -10;
+    private const int STD_OUTPUT_HANDLE = -11;
+    private const int STD_ERROR_HANDLE = -12;
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+    private const int JobObjectBasicAccountingInformation = 1;
+    private const int JobObjectExtendedLimitInformation = 9;
+    private const uint INFINITE = 0xffffffff;
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct STARTUPINFO {
+        public int cb;
+        public string lpReserved;
+        public string lpDesktop;
+        public string lpTitle;
+        public int dwX;
+        public int dwY;
+        public int dwXSize;
+        public int dwYSize;
+        public int dwXCountChars;
+        public int dwYCountChars;
+        public int dwFillAttribute;
+        public int dwFlags;
+        public short wShowWindow;
+        public short cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput;
+        public IntPtr hStdOutput;
+        public IntPtr hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public int dwProcessId;
+        public int dwThreadId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public IntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_ACCOUNTING_INFORMATION {
+        public long TotalUserTime;
+        public long TotalKernelTime;
+        public long ThisPeriodTotalUserTime;
+        public long ThisPeriodTotalKernelTime;
+        public uint TotalPageFaultCount;
+        public uint TotalProcesses;
+        public uint ActiveProcesses;
+        public uint TotalTerminatedProcesses;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr jobAttributes, string name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(
+        IntPtr job,
+        int informationClass,
+        ref JOBOBJECT_EXTENDED_LIMIT_INFORMATION information,
+        int informationLength
+    );
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool QueryInformationJobObject(
+        IntPtr job,
+        int informationClass,
+        out JOBOBJECT_BASIC_ACCOUNTING_INFORMATION information,
+        int informationLength,
+        IntPtr returnLength
+    );
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CreateProcess(
+        string applicationName,
+        StringBuilder commandLine,
+        IntPtr processAttributes,
+        IntPtr threadAttributes,
+        bool inheritHandles,
+        uint creationFlags,
+        IntPtr environment,
+        string currentDirectory,
+        ref STARTUPINFO startupInfo,
+        out PROCESS_INFORMATION processInformation
+    );
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint ResumeThread(IntPtr thread);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateProcess(IntPtr process, uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateJobObject(IntPtr job, uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GetStdHandle(int standardHandle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    private static void Check(bool result, string operation) {
+        if (!result) throw new Win32Exception(Marshal.GetLastWin32Error(), operation);
+    }
+
+    private static string Quote(string value) {
+        var quoted = new StringBuilder("\"");
+        var backslashes = 0;
+        foreach (var character in value) {
+            if (character == '\\') {
+                backslashes++;
+            } else if (character == '"') {
+                quoted.Append('\\', backslashes * 2 + 1);
+                quoted.Append(character);
+                backslashes = 0;
+            } else {
+                quoted.Append('\\', backslashes);
+                quoted.Append(character);
+                backslashes = 0;
+            }
+        }
+        quoted.Append('\\', backslashes * 2);
+        quoted.Append('"');
+        return quoted.ToString();
+    }
+
+    private static StringBuilder BuildCommandLine(string file, string[] arguments) {
+        var commandLine = new StringBuilder(Quote(file));
+        foreach (var argument in arguments) commandLine.Append(' ').Append(Quote(argument));
+        return commandLine;
+    }
+
+    private static void Drain(IntPtr job) {
+        while (true) {
+            JOBOBJECT_BASIC_ACCOUNTING_INFORMATION accounting;
+            Check(
+                QueryInformationJobObject(
+                    job,
+                    JobObjectBasicAccountingInformation,
+                    out accounting,
+                    Marshal.SizeOf(typeof(JOBOBJECT_BASIC_ACCOUNTING_INFORMATION)),
+                    IntPtr.Zero
+                ),
+                "QueryInformationJobObject"
+            );
+            if (accounting.ActiveProcesses == 0) return;
+            Thread.Sleep(10);
+        }
+    }
+
+    public static int Run(string file, string[] arguments, string workingDirectory) {
+        IntPtr job = CreateJobObject(IntPtr.Zero, null);
+        if (job == IntPtr.Zero) throw new Win32Exception(Marshal.GetLastWin32Error(), "CreateJobObject");
+
+        PROCESS_INFORMATION process = new PROCESS_INFORMATION();
+        var processCreated = false;
+        try {
+            var limits = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            Check(
+                SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    ref limits,
+                    Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION))
+                ),
+                "SetInformationJobObject"
+            );
+
+            var targetFile = file;
+            var targetArguments = arguments;
+            if (file.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase) || file.EndsWith(".bat", StringComparison.OrdinalIgnoreCase)) {
+                targetFile = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
+                targetArguments = new[] { "/d", "/s", "/c", BuildCommandLine(file, arguments).ToString() };
+            }
+
+            var startupInfo = new STARTUPINFO();
+            startupInfo.cb = Marshal.SizeOf(typeof(STARTUPINFO));
+            startupInfo.dwFlags = (int)STARTF_USESTDHANDLES;
+            startupInfo.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+            startupInfo.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+            startupInfo.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+            Check(
+                CreateProcess(
+                    targetFile,
+                    BuildCommandLine(targetFile, targetArguments),
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    true,
+                    CREATE_SUSPENDED,
+                    IntPtr.Zero,
+                    workingDirectory,
+                    ref startupInfo,
+                    out process
+                ),
+                "CreateProcessW"
+            );
+            processCreated = true;
+            try {
+                Check(AssignProcessToJobObject(job, process.hProcess), "AssignProcessToJobObject");
+            } catch {
+                TerminateProcess(process.hProcess, 1);
+                WaitForSingleObject(process.hProcess, INFINITE);
+                throw;
+            }
+            if (ResumeThread(process.hThread) == 0xffffffff) {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "ResumeThread");
+            }
+
+            WaitForSingleObject(process.hProcess, INFINITE);
+            uint exitCode;
+            Check(GetExitCodeProcess(process.hProcess, out exitCode), "GetExitCodeProcess");
+            return unchecked((int)exitCode);
+        } finally {
+            if (processCreated) {
+                Check(TerminateJobObject(job, 1), "TerminateJobObject");
+                Drain(job);
+                CloseHandle(process.hThread);
+                CloseHandle(process.hProcess);
+            }
+            CloseHandle(job);
+        }
+    }
+}
+'@
+
+	exit [EveryAstroWindowsJob]::Run($targetFile, $targetArguments, [Environment]::CurrentDirectory)
+} finally {
+	Remove-Item -LiteralPath $ControlFile -Force -ErrorAction SilentlyContinue
+}

--- a/packages/every-astro/src/windows-job-supervisor.ps1
+++ b/packages/every-astro/src/windows-job-supervisor.ps1
@@ -16,6 +16,7 @@ using System;
 using System.ComponentModel;
 using System.Text;
 using System.Threading;
+using System.Text.RegularExpressions;
 using System.Runtime.InteropServices;
 
 public static class EveryAstroWindowsJob {
@@ -229,9 +230,11 @@ public static class EveryAstroWindowsJob {
     }
 
     private static bool IsCmdShim(string file) {
-        var normalized = file.Replace('/', '\\');
-        return normalized.IndexOf("\\node_modules\\.bin\\", StringComparison.OrdinalIgnoreCase) >= 0 &&
-            normalized.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase);
+        return Regex.IsMatch(
+            file,
+            @"node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$",
+            RegexOptions.IgnoreCase
+        );
     }
 
     private static StringBuilder BuildCmdCommandLine(string cmd, string batchFile, string[] arguments) {

--- a/packages/every-astro/src/workflow.ts
+++ b/packages/every-astro/src/workflow.ts
@@ -9,6 +9,7 @@ export interface BisectSession {
 }
 
 export interface EveryAstroDependencies {
+	readonly signal: AbortSignal;
 	installedAstroMajor(): Promise<number>;
 	createSession(): Promise<BisectSession>;
 	log(message: string): void;
@@ -82,5 +83,6 @@ export async function runEveryAstro(deps: EveryAstroDependencies): Promise<void>
 		}
 	}
 
+	deps.signal.throwIfAborted();
 	deps.log(result);
 }

--- a/packages/every-astro/src/workflow.ts
+++ b/packages/every-astro/src/workflow.ts
@@ -49,7 +49,7 @@ export async function runEveryAstro(deps: EveryAstroDependencies): Promise<void>
 		} else {
 			await session.prepareRevision(firstReleaseRevision);
 			if (await session.runDevServerAndAsk(firstReleaseLabel)) {
-				result = `The bug is already present in Astro v${astroMajor}.0.0; its introduction is outside the selected major range.`;
+				result = `The bug is already present in Astro v${astroMajor}.0.0; its introduction is at or before the first-release boundary, and earlier history is not bisected.`;
 			} else {
 				await session.startBisect(firstReleaseRevision, latestRevision);
 

--- a/packages/every-astro/src/workflow.ts
+++ b/packages/every-astro/src/workflow.ts
@@ -14,11 +14,29 @@ export interface EveryAstroDependencies {
 	log(message: string): void;
 }
 
+export class WorkflowCleanupError extends AggregateError {
+	public constructor(
+		readonly primaryError: unknown,
+		readonly cleanupError: unknown
+	) {
+		super([primaryError, cleanupError], 'Workflow operation and session cleanup both failed.', {
+			cause: primaryError,
+		});
+		this.name = 'WorkflowCleanupError';
+	}
+}
+
+export function isPlainAbortError(error: unknown): error is Error {
+	return error instanceof Error && error.name === 'AbortError';
+}
+
 export async function runEveryAstro(deps: EveryAstroDependencies): Promise<void> {
 	const astroMajor = await deps.installedAstroMajor();
 	const firstReleaseRevision = `astro@${astroMajor}.0.0`;
 	const firstReleaseLabel = `v${astroMajor}.0.0`;
 	const session = await deps.createSession();
+	let operationFailed = false;
+	let operationError: unknown;
 	let result: string | undefined;
 
 	try {
@@ -48,8 +66,20 @@ export async function runEveryAstro(deps: EveryAstroDependencies): Promise<void>
 				}
 			}
 		}
+	} catch (error) {
+		operationFailed = true;
+		operationError = error;
+		throw error;
 	} finally {
-		await session.close();
+		try {
+			await session.close();
+		} catch (cleanupError) {
+			if (operationFailed) {
+				throw new WorkflowCleanupError(operationError, cleanupError);
+			}
+
+			throw cleanupError;
+		}
 	}
 
 	deps.log(result);

--- a/packages/every-astro/src/workflow.ts
+++ b/packages/every-astro/src/workflow.ts
@@ -1,0 +1,56 @@
+export interface BisectSession {
+	latestRevision(): Promise<string>;
+	prepareRevision(revision: string): Promise<void>;
+	runDevServerAndAsk(label: string): Promise<boolean>;
+	startBisect(good: string, bad: string): Promise<void>;
+	currentRevision(): Promise<string>;
+	markCurrent(isBad: boolean): Promise<string | undefined>;
+	close(): Promise<void>;
+}
+
+export interface EveryAstroDependencies {
+	installedAstroMajor(): Promise<number>;
+	createSession(): Promise<BisectSession>;
+	log(message: string): void;
+}
+
+export async function runEveryAstro(deps: EveryAstroDependencies): Promise<void> {
+	const astroMajor = await deps.installedAstroMajor();
+	const firstReleaseRevision = `astro@${astroMajor}.0.0`;
+	const firstReleaseLabel = `v${astroMajor}.0.0`;
+	const session = await deps.createSession();
+	let result: string | undefined;
+
+	try {
+		const latestRevision = await session.latestRevision();
+
+		await session.prepareRevision(latestRevision);
+		if (!(await session.runDevServerAndAsk('latest'))) {
+			result = 'The bug is already fixed in the latest Astro revision.';
+		} else {
+			await session.prepareRevision(firstReleaseRevision);
+			if (await session.runDevServerAndAsk(firstReleaseLabel)) {
+				result = `The bug predates Astro v${astroMajor}.`;
+			} else {
+				await session.startBisect(firstReleaseRevision, latestRevision);
+
+				while (result === undefined) {
+					const revision = await session.currentRevision();
+
+					await session.prepareRevision(revision);
+					const firstBadRevision = await session.markCurrent(
+						await session.runDevServerAndAsk(revision)
+					);
+
+					if (firstBadRevision !== undefined) {
+						result = `The bug was introduced in Astro commit ${firstBadRevision}.`;
+					}
+				}
+			}
+		}
+	} finally {
+		await session.close();
+	}
+
+	deps.log(result);
+}

--- a/packages/every-astro/src/workflow.ts
+++ b/packages/every-astro/src/workflow.ts
@@ -43,12 +43,12 @@ export async function runEveryAstro(deps: EveryAstroDependencies): Promise<void>
 		const latestRevision = await session.latestRevision();
 
 		await session.prepareRevision(latestRevision);
-		if (!(await session.runDevServerAndAsk('latest'))) {
-			result = 'The bug is already fixed in the latest Astro revision.';
+		if (!(await session.runDevServerAndAsk(`latest v${astroMajor}`))) {
+			result = `The bug is already fixed in the latest Astro revision in the installed major (v${astroMajor}).`;
 		} else {
 			await session.prepareRevision(firstReleaseRevision);
 			if (await session.runDevServerAndAsk(firstReleaseLabel)) {
-				result = `The bug predates Astro v${astroMajor}.`;
+				result = `The bug is already present in Astro v${astroMajor}.0.0; its introduction is outside the selected major range.`;
 			} else {
 				await session.startBisect(firstReleaseRevision, latestRevision);
 

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -111,6 +111,67 @@ describe('installedAstroMajor', () => {
 	});
 });
 
+test.each([
+	['nonzero exit', 'failure'],
+	['malformed manifest', 'malformed'],
+])('reaps a background PnP reader descendant after a %s', async (_name, mode) => {
+	const project = await createProject({
+		packageManager: 'yarn@4.17.1',
+		dependencies: { astro: '7.0.0' },
+	});
+	const pidDirectory = join(project, 'reader-pids');
+	const packageRoot = join(project, '.yarn/cache/astro.zip/node_modules/astro');
+	await mkdir(pidDirectory, { recursive: true });
+	await mkdir(join(project, '.yarn/cache'), { recursive: true });
+	await writeFile(join(project, '.yarn/cache/astro.zip'), '');
+	await writeFile(
+		join(project, '.pnp.cjs'),
+		`exports.resolveToUnqualified = (request) => request === 'astro' ? ${JSON.stringify(packageRoot)} : null;\n`
+	);
+	await writeFile(
+		join(project, '.yarnrc.yml'),
+		'yarnPath: .yarn/releases/reader.cjs\nnodeLinker: pnp\n'
+	);
+	// The unrefed fixture child must outlive its launcher until reader cleanup owns it.
+	await mkdir(join(project, '.yarn/releases'), { recursive: true });
+	await writeFile(
+		join(project, '.yarn/releases/reader.cjs'),
+		[
+			"const { spawn } = require('node:child_process');",
+			"const { mkdirSync, writeFileSync } = require('node:fs');",
+			"const { join } = require('node:path');",
+			'const directory = process.env.EVERY_ASTRO_PNP_READER_PIDS;',
+			"if (!directory) throw new Error('Missing PID directory');",
+			'mkdirSync(directory, { recursive: true });',
+			"const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], { stdio: 'ignore' });",
+			'descendant.unref();',
+			"writeFileSync(join(directory, `reader-${process.pid}`), '');",
+			"writeFileSync(join(directory, `descendant-${descendant.pid}`), '');",
+			mode === 'malformed' ? "process.stdout.write('not JSON');" : '',
+			mode === 'malformed' ? 'process.exit(0);' : 'process.exit(1);',
+		].join('\n')
+	);
+	const previousPidDirectory = process.env.EVERY_ASTRO_PNP_READER_PIDS;
+	process.env.EVERY_ASTRO_PNP_READER_PIDS = pidDirectory;
+	try {
+		if (mode === 'malformed') {
+			await expect(installedAstroMajor(project)).rejects.toThrow(SyntaxError);
+		} else {
+			await expect(installedAstroMajor(project)).rejects.toThrow('Could not read PnP manifest');
+		}
+		const pids = (await readdir(pidDirectory))
+			.map((entry) => Number(entry.slice(entry.lastIndexOf('-') + 1)))
+			.filter(Number.isSafeInteger);
+		expect(pids).toHaveLength(2);
+		for (const pid of pids) {
+			expect(() => process.kill(pid, 0)).toThrow(/ESRCH/);
+		}
+	} finally {
+		if (previousPidDirectory === undefined) delete process.env.EVERY_ASTRO_PNP_READER_PIDS;
+		else process.env.EVERY_ASTRO_PNP_READER_PIDS = previousPidDirectory;
+	}
+});
+
 describe('selectLatestAstroReleaseTag', () => {
 	test('selects the newest stable tag within the installed Astro major', () => {
 		expect(

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -510,10 +510,10 @@ test.skipIf(process.platform !== 'win32')(
 					() =>
 						finish(
 							new Error(
-								`Supervisor did not signal readiness within 2 seconds${output ? `:\n${output}` : ''}`
+								`Supervisor did not signal readiness within 10 seconds${output ? `:\n${output}` : ''}`
 							)
 						),
-					2_000
+					10_000
 				);
 			});
 			const closed = once(runningSupervisor, 'close');

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -29,6 +29,7 @@ import {
 	installedAstroMajor,
 	isolatedBootstrapEnvironment,
 	windowsJobSupervisorCommand,
+	windowsBatchCommandTail,
 	linkBunPackage,
 	packageLinkCommands,
 	parseBisectCompletion,
@@ -418,10 +419,17 @@ test.skipIf(process.platform !== 'win32')(
 	'launches a target through the Job Object supervisor and removes its control file',
 	async () => {
 		const root = await temporaryRoot();
+		const toolRoot = join(root, 'tool path');
+		const batchFile = join(toolRoot, 'runner.cmd');
 		const controlFile = join(root, 'command.json');
+		await mkdir(toolRoot);
+		await writeFile(batchFile, '@echo off\r\nexit /b 0\r\n');
 		await writeFile(
 			controlFile,
-			JSON.stringify({ file: process.execPath, args: ['-e', 'process.exit(0)'] })
+			JSON.stringify({
+				file: batchFile,
+				args: ['spaced argument', '%literal%', 'a&b'],
+			})
 		);
 		const [file, ...args] = windowsJobSupervisorCommand(controlFile);
 		const child = spawnChild(file, args, { cwd: root, stdio: 'ignore' });
@@ -432,6 +440,17 @@ test.skipIf(process.platform !== 'win32')(
 		await expect(readFile(controlFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
 	}
 );
+
+describe('windowsBatchCommandTail', () => {
+	test('ports cross-spawn escaping for batch paths, spaces, percent variables, and metacharacters', () => {
+		expect(
+			windowsBatchCommandTail('C:\\tool path\\runner.cmd', ['spaced argument', '%literal%', 'a&b'])
+		).toBe('/d /s /c "C:\\tool^ path\\runner.cmd ^"spaced^ argument^" ^"^%literal^%^" ^"a^&b^""');
+		expect(windowsBatchCommandTail('C:\\p\\node_modules\\.bin\\tool.cmd', ['a&b'])).toBe(
+			'/d /s /c "C:\\p\\node_modules\\.bin\\tool.cmd ^^^"a^^^&b^^^""'
+		);
+	});
+});
 
 describe('developmentServerStdio', () => {
 	test('reserves stdin for the interactive bisect prompt', () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -430,26 +430,36 @@ test.skipIf(process.platform !== 'win32')(
 		const targetScript = join(toolRoot, 'target.mjs');
 		const descendantScript = join(toolRoot, 'descendant.mjs');
 		const sentinelFile = join(root, 'descendant-survived');
+		const startedFile = join(root, 'descendant-started');
 		const controlFile = join(root, 'command.json');
 		await mkdir(toolRoot);
 		await writeFile(
 			descendantScript,
 			[
+				"import { writeFileSync } from 'node:fs';",
 				"import { writeFile } from 'node:fs/promises';",
 				"import { setTimeout as delay } from 'node:timers/promises';",
+				"writeFileSync(process.argv[2], 'started');",
 				'await delay(250);',
-				"await writeFile(process.argv[2], 'escaped');",
+				"await writeFile(process.argv[3], 'escaped');",
 			].join('\n')
 		);
 		await writeFile(
 			targetScript,
 			[
 				"import { spawn } from 'node:child_process';",
+				"import { existsSync } from 'node:fs';",
 				"import { setTimeout as delay } from 'node:timers/promises';",
-				`const descendant = spawn(process.execPath, [${JSON.stringify(descendantScript)}, process.argv[2]], {`,
+				'const [startedFile, sentinelFile] = process.argv.slice(2);',
+				`const descendant = spawn(process.execPath, [${JSON.stringify(descendantScript)}, startedFile, sentinelFile], {`,
 				"\tstdio: 'ignore',",
 				'});',
 				'descendant.unref();',
+				'const deadline = Date.now() + 5_000;',
+				'while (!existsSync(startedFile)) {',
+				"\tif (Date.now() >= deadline) throw new Error('Descendant did not start');",
+				'\tawait delay(10);',
+				'}',
 				"console.log('ready');",
 				'await delay(600);',
 			].join('\n')
@@ -459,7 +469,7 @@ test.skipIf(process.platform !== 'win32')(
 			controlFile,
 			JSON.stringify({
 				file: batchFile,
-				args: [sentinelFile],
+				args: [startedFile, sentinelFile],
 			})
 		);
 		const [file, ...args] = windowsJobSupervisorCommand(controlFile);
@@ -516,6 +526,7 @@ test.skipIf(process.platform !== 'win32')(
 					10_000
 				);
 			});
+			await expect(readFile(startedFile, 'utf8')).resolves.toBe('started');
 			const closed = once(runningSupervisor, 'close');
 			expect(runningSupervisor.kill()).toBe(true);
 			await closed;

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -799,11 +799,11 @@ describe('isolatedBootstrapEnvironment', () => {
 		});
 	});
 
-	test('removes fully quoted loader options while preserving fully quoted non-loaders', () => {
+	test('removes fully quoted dashed and underscored loader options while preserving quoted non-loaders', () => {
 		expect(
 			isolatedBootstrapEnvironment({
 				NODE_OPTIONS:
-					'"--require=C:\\project\\double.cjs" \'--import=./single.mjs\' "--loader" "./double-loader.mjs" \'--experimental-loader\' \'./single-loader.mjs\' "--max-old-space-size=4096" \'--conditions=development\'',
+					'"--require=C:\\project\\double.cjs" \'--import=./single.mjs\' "--loader" "./double-loader.mjs" \'--experimental-loader\' \'./single-loader.mjs\' \'--experimental_loader=./single-alias.mjs\' "--experimental_loader" "./double-alias.mjs" "--max-old-space-size=4096" \'--conditions=development\'',
 			})
 		).toEqual({
 			NODE_OPTIONS: '"--max-old-space-size=4096" \'--conditions=development\'',

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -112,9 +112,10 @@ describe('installedAstroMajor', () => {
 });
 
 test.each([
+	['successful manifest', 'success'],
 	['nonzero exit', 'failure'],
 	['malformed manifest', 'malformed'],
-])('reaps a background PnP reader descendant after a %s', async (_name, mode) => {
+])('reaps a pipe-inheriting PnP reader descendant after a %s', async (_name, mode) => {
 	const project = await createProject({
 		packageManager: 'yarn@4.17.1',
 		dependencies: { astro: '7.0.0' },
@@ -143,21 +144,30 @@ test.each([
 			'const directory = process.env.EVERY_ASTRO_PNP_READER_PIDS;',
 			"if (!directory) throw new Error('Missing PID directory');",
 			'mkdirSync(directory, { recursive: true });',
-			"const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], { stdio: 'ignore' });",
+			"const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], { stdio: 'inherit' });",
 			'descendant.unref();',
 			"writeFileSync(join(directory, `reader-${process.pid}`), '');",
 			"writeFileSync(join(directory, `descendant-${descendant.pid}`), '');",
-			mode === 'malformed' ? "process.stdout.write('not JSON');" : '',
-			mode === 'malformed' ? 'process.exit(0);' : 'process.exit(1);',
+			"process.stderr.write('reader stderr');",
+			mode === 'success'
+				? "process.stdout.write(JSON.stringify({ name: 'astro', version: '7.0.0' }));"
+				: mode === 'malformed'
+					? "process.stdout.write('not JSON');"
+					: '',
+			mode === 'failure' ? 'process.exit(1);' : 'process.exit(0);',
 		].join('\n')
 	);
 	const previousPidDirectory = process.env.EVERY_ASTRO_PNP_READER_PIDS;
 	process.env.EVERY_ASTRO_PNP_READER_PIDS = pidDirectory;
 	try {
-		if (mode === 'malformed') {
+		if (mode === 'success') {
+			await expect(installedAstroMajor(project)).resolves.toBe(7);
+		} else if (mode === 'malformed') {
 			await expect(installedAstroMajor(project)).rejects.toThrow(SyntaxError);
 		} else {
-			await expect(installedAstroMajor(project)).rejects.toThrow('Could not read PnP manifest');
+			await expect(installedAstroMajor(project)).rejects.toThrow(
+				/Could not read PnP manifest[\s\S]*reader stderr/
+			);
 		}
 		const pids = (await readdir(pidDirectory))
 			.map((entry) => Number(entry.slice(entry.lastIndexOf('-') + 1)))
@@ -252,7 +262,7 @@ test.skipIf(process.platform === 'win32')(
 				"const { writeFileSync } = require('node:fs');",
 				"const { join } = require('node:path');",
 				'const directory = process.env.EVERY_ASTRO_PNP_READER_PIDS;',
-				"const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], { stdio: 'ignore' });",
+				"const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], { stdio: 'inherit' });",
 				'descendant.unref();',
 				"writeFileSync(join(directory, `reader-${process.pid}`), '');",
 				"writeFileSync(join(directory, `descendant-${descendant.pid}`), '');",

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -799,11 +799,11 @@ describe('isolatedBootstrapEnvironment', () => {
 		});
 	});
 
-	test('removes fully quoted dashed and underscored loader options while preserving quoted non-loaders', () => {
+	test('removes quoted loader option spellings while preserving quoted non-loaders', () => {
 		expect(
 			isolatedBootstrapEnvironment({
 				NODE_OPTIONS:
-					'"--require=C:\\project\\double.cjs" \'--import=./single.mjs\' "--loader" "./double-loader.mjs" \'--experimental-loader\' \'./single-loader.mjs\' \'--experimental_loader=./single-alias.mjs\' "--experimental_loader" "./double-alias.mjs" "--max-old-space-size=4096" \'--conditions=development\'',
+					'"--require=C:\\project\\double.cjs" \'--import=./single.mjs\' "--loader" "./double-loader.mjs" \'--experimental-loader\' \'./single-loader.mjs\' \'--experimental_loader=./single-alias.mjs\' "--experimental_loader" "./double-alias.mjs" "--require"="./double mixed.cjs" \'--experimental_loader\'="./single mixed.mjs" "--max-old-space-size=4096" \'--conditions=development\'',
 			})
 		).toEqual({
 			NODE_OPTIONS: '"--max-old-space-size=4096" \'--conditions=development\'',

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -16,17 +16,19 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
 	abortError,
+	assertFirstAstroReleaseTag,
 	collectInstalledDependencyNames,
 	collectAstroWorkspacePackageClosure,
 	createRuntimeDependencies,
 	determineBisectProgress,
+	developmentServerStdio,
 	dependencySymlinkType,
 	detectPackageManager,
 	detectPackageManagerRoot,
 	discoverAstroWorkspacePackages,
 	installedAstroMajor,
 	isolatedBootstrapEnvironment,
-	isWindowsForegroundDevScript,
+	windowsJobSupervisorCommand,
 	linkBunPackage,
 	packageLinkCommands,
 	parseBisectCompletion,
@@ -119,6 +121,15 @@ describe('selectLatestAstroReleaseTag', () => {
 		expect(() => selectLatestAstroReleaseTag(['astro@8.0.0', 'astro@7.5.0-rc.1'], 7)).toThrow(
 			'Could not find a stable Astro 7 release tag'
 		);
+	});
+
+	test('requires the real stable first release before bisecting an installed major', () => {
+		expect(() => assertFirstAstroReleaseTag(['astro@8.0.0-beta.1'], 8)).toThrow(
+			'Astro 8 has no stable first-release bisect boundary (astro@8.0.0)'
+		);
+		expect(() =>
+			assertFirstAstroReleaseTag(['astro@8.0.0', 'astro@8.0.0-beta.1'], 8)
+		).not.toThrow();
 	});
 
 	test('selects the commit revision rather than a tag object for bisecting', () => {
@@ -392,15 +403,39 @@ describe('terminateChildProcess', () => {
 	});
 });
 
-describe('isWindowsForegroundDevScript', () => {
-	test('accepts direct Astro dev commands and rejects wrappers or shell composition', () => {
-		expect(isWindowsForegroundDevScript('astro dev --host')).toBe(true);
-		expect(isWindowsForegroundDevScript('pnpm exec astro dev')).toBe(true);
-		expect(isWindowsForegroundDevScript('npx astro dev')).toBe(true);
-		expect(isWindowsForegroundDevScript('node scripts/start-dev.js')).toBe(false);
-		expect(isWindowsForegroundDevScript('astro dev &')).toBe(false);
-		expect(isWindowsForegroundDevScript('astro dev | tee dev.log')).toBe(false);
-		expect(isWindowsForegroundDevScript('astro dev $(node daemonize.js)')).toBe(false);
+describe('windowsJobSupervisorCommand', () => {
+	test('passes a JSON control-file path to the shipped PowerShell supervisor', () => {
+		const command = windowsJobSupervisorCommand('C:\\temp\\every-astro-command.json');
+
+		expect(command[0]).toBe('powershell.exe');
+		expect(command).toContain('-File');
+		expect(command[command.indexOf('-File') + 1]).toMatch(/src[\\/]windows-job-supervisor\.ps1$/);
+		expect(command.slice(-2)).toEqual(['-ControlFile', 'C:\\temp\\every-astro-command.json']);
+	});
+});
+
+test.skipIf(process.platform !== 'win32')(
+	'launches a target through the Job Object supervisor and removes its control file',
+	async () => {
+		const root = await temporaryRoot();
+		const controlFile = join(root, 'command.json');
+		await writeFile(
+			controlFile,
+			JSON.stringify({ file: process.execPath, args: ['-e', 'process.exit(0)'] })
+		);
+		const [file, ...args] = windowsJobSupervisorCommand(controlFile);
+		const child = spawnChild(file, args, { cwd: root, stdio: 'ignore' });
+
+		const [exitCode] = (await once(child, 'close')) as [number | null];
+
+		expect(exitCode).toBe(0);
+		await expect(readFile(controlFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+	}
+);
+
+describe('developmentServerStdio', () => {
+	test('reserves stdin for the interactive bisect prompt', () => {
+		expect(developmentServerStdio).toEqual(['ignore', 'inherit', 'inherit']);
 	});
 });
 

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -809,6 +809,32 @@ describe('isolatedBootstrapEnvironment', () => {
 			NODE_OPTIONS: '"--max-old-space-size=4096" \'--conditions=development\'',
 		});
 	});
+
+	test('preserves escaped quotes inside retained Node options', () => {
+		const nodeOptions = '--conditions="foo\\" bar" --trace-warnings';
+
+		expect(isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions })).toEqual({
+			NODE_OPTIONS: nodeOptions,
+		});
+	});
+
+	test('removes a loader token containing an escaped quote without retaining its tail', () => {
+		expect(
+			isolatedBootstrapEnvironment({
+				NODE_OPTIONS: '--require="/tmp/hook\\" name.cjs" --trace-warnings',
+			})
+		).toEqual({ NODE_OPTIONS: '--trace-warnings' });
+	});
+
+	test('preserves malformed Node options for Node to reject', async () => {
+		const nodeOptions = '--conditions="unterminated';
+		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
+
+		expect(environment).toEqual({ NODE_OPTIONS: nodeOptions });
+		await expect(
+			runCommand(process.execPath, ['--version'], process.cwd(), environment)
+		).rejects.toThrow('invalid value for NODE_OPTIONS');
+	});
 });
 
 describe('createRuntimeDependencies', () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -1,7 +1,6 @@
 import { type ChildProcess, spawn as spawnChild } from 'node:child_process';
-import { once } from 'node:events';
+import { EventEmitter, once } from 'node:events';
 import {
-	chmod,
 	mkdir,
 	mkdtemp,
 	readFile,
@@ -217,149 +216,76 @@ describe('terminateChildProcess', () => {
 	);
 
 	test('shares Windows taskkill across concurrent and late stop requests', async () => {
-		const root = await temporaryRoot();
-		const bin = join(root, 'bin');
-		const log = join(root, 'taskkill.log');
-		const taskkill = join(bin, 'taskkill');
-		await mkdir(bin);
-		await writeFile(taskkill, '#!/bin/sh\nprintf "%s\\n" "$@" >> "$TASKKILL_LOG"\nsleep 0.05\n');
-		await chmod(taskkill, 0o755);
+		const child = { pid: 4_242, exitCode: null, signalCode: null } as ChildProcess;
+		const taskkill = new EventEmitter();
+		const launchTaskkill = vi.fn<(pid: number) => ChildProcess>(() => taskkill as ChildProcess);
+		const first = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+		const second = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
 
-		const originalPath = process.env.PATH;
-		const originalLog = process.env.TASKKILL_LOG;
-		process.env.PATH = `${bin}:${originalPath ?? ''}`;
-		process.env.TASKKILL_LOG = log;
-		try {
-			const child = { pid: process.pid, exitCode: null, signalCode: null } as ChildProcess;
-			const first = terminateChildProcess(child, 'win32');
-			const second = terminateChildProcess(child, 'win32');
+		expect(second).toBe(first);
+		expect(launchTaskkill).toHaveBeenCalledExactlyOnceWith(4_242);
+		taskkill.emit('close', 0);
+		await Promise.all([first, second]);
+		await terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
 
-			expect(second).toBe(first);
-			await Promise.all([first, second]);
-			await terminateChildProcess(child, 'win32');
-
-			expect((await readFile(log, 'utf8')).match(/^\/pid$/gm) ?? []).toHaveLength(1);
-		} finally {
-			if (originalPath === undefined) delete process.env.PATH;
-			else process.env.PATH = originalPath;
-			if (originalLog === undefined) delete process.env.TASKKILL_LOG;
-			else process.env.TASKKILL_LOG = originalLog;
-		}
+		expect(launchTaskkill).toHaveBeenCalledExactlyOnceWith(4_242);
 	});
 
 	test('does not taskkill a Windows child that exited naturally', async () => {
-		const root = await temporaryRoot();
-		const bin = join(root, 'bin');
-		const log = join(root, 'taskkill.log');
-		const taskkill = join(bin, 'taskkill');
-		await mkdir(bin);
-		await writeFile(taskkill, '#!/bin/sh\nprintf "%s\\n" "$@" >> "$TASKKILL_LOG"\n');
-		await chmod(taskkill, 0o755);
+		const child = { pid: 4_242, exitCode: 0, signalCode: null } as ChildProcess;
+		const launchTaskkill = vi.fn<(pid: number) => ChildProcess>();
+		const first = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+		const late = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
 
-		const originalPath = process.env.PATH;
-		const originalLog = process.env.TASKKILL_LOG;
-		process.env.PATH = `${bin}:${originalPath ?? ''}`;
-		process.env.TASKKILL_LOG = log;
-		try {
-			const child = { pid: process.pid, exitCode: 0, signalCode: null } as ChildProcess;
-			const first = terminateChildProcess(child, 'win32');
-			const late = terminateChildProcess(child, 'win32');
-
-			expect(late).toBe(first);
-			await first;
-			await expect(readFile(log, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
-		} finally {
-			if (originalPath === undefined) delete process.env.PATH;
-			else process.env.PATH = originalPath;
-			if (originalLog === undefined) delete process.env.TASKKILL_LOG;
-			else process.env.TASKKILL_LOG = originalLog;
-		}
+		expect(late).toBe(first);
+		await first;
+		expect(launchTaskkill).not.toHaveBeenCalled();
 	});
 
 	test('accepts a Windows taskkill race after the child exits', async () => {
-		const root = await temporaryRoot();
-		const bin = join(root, 'bin');
-		const log = join(root, 'taskkill.log');
-		const taskkill = join(bin, 'taskkill');
-		await mkdir(bin);
-		await writeFile(
-			taskkill,
-			'#!/bin/sh\nprintf "%s\\n" "$@" >> "$TASKKILL_LOG"\nsleep 0.05\nexit 1\n'
-		);
-		await chmod(taskkill, 0o755);
+		const taskkill = new EventEmitter();
+		const launchTaskkill = vi.fn<(pid: number) => ChildProcess>(() => taskkill as ChildProcess);
+		const testChild = { pid: 4_242, exitCode: null as number | null, signalCode: null };
+		const child = testChild as ChildProcess;
+		const termination = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+		testChild.exitCode = 0;
+		taskkill.emit('close', 1);
 
-		const originalPath = process.env.PATH;
-		const originalLog = process.env.TASKKILL_LOG;
-		process.env.PATH = `${bin}:${originalPath ?? ''}`;
-		process.env.TASKKILL_LOG = log;
-		try {
-			const testChild = { pid: process.pid, exitCode: null as number | null, signalCode: null };
-			const child = testChild as ChildProcess;
-			const termination = terminateChildProcess(child, 'win32');
-			testChild.exitCode = 0;
-
-			await expect(termination).resolves.toBeUndefined();
-			expect((await readFile(log, 'utf8')).match(/^\/pid$/gm) ?? []).toHaveLength(1);
-		} finally {
-			if (originalPath === undefined) delete process.env.PATH;
-			else process.env.PATH = originalPath;
-			if (originalLog === undefined) delete process.env.TASKKILL_LOG;
-			else process.env.TASKKILL_LOG = originalLog;
-		}
+		await expect(termination).resolves.toBeUndefined();
+		expect(launchTaskkill).toHaveBeenCalledExactlyOnceWith(4_242);
 	});
 
 	test('reports a Windows taskkill failure while the child is still running', async () => {
-		const root = await temporaryRoot();
-		const bin = join(root, 'bin');
-		const taskkill = join(bin, 'taskkill');
-		await mkdir(bin);
-		await writeFile(taskkill, '#!/bin/sh\nexit 1\n');
-		await chmod(taskkill, 0o755);
+		const child = { pid: 4_242, exitCode: null, signalCode: null } as ChildProcess;
+		const taskkill = new EventEmitter();
+		const launchTaskkill = vi.fn<(pid: number) => ChildProcess>(() => taskkill as ChildProcess);
+		const termination = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+		taskkill.emit('close', 1);
 
-		const originalPath = process.env.PATH;
-		process.env.PATH = `${bin}:${originalPath ?? ''}`;
-		try {
-			const child = { pid: process.pid, exitCode: null, signalCode: null } as ChildProcess;
-
-			await expect(terminateChildProcess(child, 'win32')).rejects.toThrow(
-				`taskkill failed while terminating process ${process.pid} (exit code 1)`
-			);
-		} finally {
-			if (originalPath === undefined) delete process.env.PATH;
-			else process.env.PATH = originalPath;
-		}
+		await expect(termination).rejects.toThrow(
+			'taskkill failed while terminating process 4242 (exit code 1)'
+		);
 	});
 
 	test('evicts a failed Windows termination so a later cleanup retry can stop the child', async () => {
-		const root = await temporaryRoot();
-		const bin = join(root, 'bin');
-		const attempts = join(root, 'taskkill-attempts');
-		const taskkill = join(bin, 'taskkill');
-		await mkdir(bin);
-		await writeFile(
-			taskkill,
-			'#!/bin/sh\nif [ -e "$TASKKILL_ATTEMPTS" ]; then\n\tprintf 2 > "$TASKKILL_ATTEMPTS"\n\texit 0\nfi\nprintf 1 > "$TASKKILL_ATTEMPTS"\nexit 1\n'
+		const child = { pid: 4_242, exitCode: null, signalCode: null } as ChildProcess;
+		const firstTaskkill = new EventEmitter();
+		const secondTaskkill = new EventEmitter();
+		const launchTaskkill = vi
+			.fn<(pid: number) => ChildProcess>()
+			.mockReturnValueOnce(firstTaskkill as ChildProcess)
+			.mockReturnValueOnce(secondTaskkill as ChildProcess);
+		const first = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+		firstTaskkill.emit('close', 1);
+
+		await expect(first).rejects.toThrow(
+			'taskkill failed while terminating process 4242 (exit code 1)'
 		);
-		await chmod(taskkill, 0o755);
+		const second = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+		secondTaskkill.emit('close', 0);
 
-		const originalPath = process.env.PATH;
-		const originalAttempts = process.env.TASKKILL_ATTEMPTS;
-		process.env.PATH = `${bin}:${originalPath ?? ''}`;
-		process.env.TASKKILL_ATTEMPTS = attempts;
-		try {
-			const child = { pid: process.pid, exitCode: null, signalCode: null } as ChildProcess;
-
-			await expect(terminateChildProcess(child, 'win32')).rejects.toThrow(
-				`taskkill failed while terminating process ${process.pid} (exit code 1)`
-			);
-			await expect(terminateChildProcess(child, 'win32')).resolves.toBeUndefined();
-			await expect(readFile(attempts, 'utf8')).resolves.toBe('2');
-		} finally {
-			if (originalPath === undefined) delete process.env.PATH;
-			else process.env.PATH = originalPath;
-			if (originalAttempts === undefined) delete process.env.TASKKILL_ATTEMPTS;
-			else process.env.TASKKILL_ATTEMPTS = originalAttempts;
-		}
+		await expect(second).resolves.toBeUndefined();
+		expect(launchTaskkill).toHaveBeenCalledTimes(2);
 	});
 
 	test('rejects an aborted command when termination fails and retries it during cleanup', async () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -13,7 +13,7 @@ import {
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
 	abortError,
 	collectInstalledDependencyNames,
@@ -26,9 +26,11 @@ import {
 	discoverAstroWorkspacePackages,
 	installedAstroMajor,
 	isolatedBootstrapEnvironment,
+	isWindowsForegroundDevScript,
 	linkBunPackage,
 	packageLinkCommands,
 	parseBisectCompletion,
+	RuntimeSession,
 	resolveInstalledPackageManifest,
 	restoreDependencySymlink,
 	selectLatestAstroReleaseTag,
@@ -314,6 +316,91 @@ describe('terminateChildProcess', () => {
 			if (originalPath === undefined) delete process.env.PATH;
 			else process.env.PATH = originalPath;
 		}
+	});
+
+	test('evicts a failed Windows termination so a later cleanup retry can stop the child', async () => {
+		const root = await temporaryRoot();
+		const bin = join(root, 'bin');
+		const attempts = join(root, 'taskkill-attempts');
+		const taskkill = join(bin, 'taskkill');
+		await mkdir(bin);
+		await writeFile(
+			taskkill,
+			'#!/bin/sh\nif [ -e "$TASKKILL_ATTEMPTS" ]; then\n\tprintf 2 > "$TASKKILL_ATTEMPTS"\n\texit 0\nfi\nprintf 1 > "$TASKKILL_ATTEMPTS"\nexit 1\n'
+		);
+		await chmod(taskkill, 0o755);
+
+		const originalPath = process.env.PATH;
+		const originalAttempts = process.env.TASKKILL_ATTEMPTS;
+		process.env.PATH = `${bin}:${originalPath ?? ''}`;
+		process.env.TASKKILL_ATTEMPTS = attempts;
+		try {
+			const child = { pid: process.pid, exitCode: null, signalCode: null } as ChildProcess;
+
+			await expect(terminateChildProcess(child, 'win32')).rejects.toThrow(
+				`taskkill failed while terminating process ${process.pid} (exit code 1)`
+			);
+			await expect(terminateChildProcess(child, 'win32')).resolves.toBeUndefined();
+			await expect(readFile(attempts, 'utf8')).resolves.toBe('2');
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			if (originalAttempts === undefined) delete process.env.TASKKILL_ATTEMPTS;
+			else process.env.TASKKILL_ATTEMPTS = originalAttempts;
+		}
+	});
+
+	test('rejects an aborted command when termination fails and retries it during cleanup', async () => {
+		const project = await createProject();
+		const temporary = await temporaryRoot();
+		const controller = new AbortController();
+		const terminationError = new Error('could not terminate child');
+		const terminate = vi.fn(async () => {
+			throw terminationError;
+		});
+		const session = new RuntimeSession(
+			project,
+			project,
+			join(temporary, 'astro'),
+			temporary,
+			'',
+			'npm',
+			false,
+			{ exists: true, content: Buffer.from('{}\n') },
+			{ exists: true, content: Buffer.from('{}\n') },
+			join(project, 'package-lock.json'),
+			{ exists: true, content: Buffer.from('{}\n') },
+			[],
+			new Set(),
+			'',
+			controller.signal,
+			terminate
+		);
+		const controllableSession = session as unknown as {
+			unlinkPackages(): Promise<void>;
+			restoreDependencies(): Promise<void>;
+		};
+		vi.spyOn(controllableSession, 'unlinkPackages').mockResolvedValue();
+		vi.spyOn(controllableSession, 'restoreDependencies').mockResolvedValue();
+
+		const execution = session.execute([process.execPath, '-e', ''], project);
+		controller.abort();
+
+		await expect(execution).rejects.toBe(terminationError);
+		await expect(session.close()).rejects.toThrow('every-astro cleanup failed');
+		expect(terminate).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('isWindowsForegroundDevScript', () => {
+	test('accepts direct Astro dev commands and rejects wrappers or shell composition', () => {
+		expect(isWindowsForegroundDevScript('astro dev --host')).toBe(true);
+		expect(isWindowsForegroundDevScript('pnpm exec astro dev')).toBe(true);
+		expect(isWindowsForegroundDevScript('npx astro dev')).toBe(true);
+		expect(isWindowsForegroundDevScript('node scripts/start-dev.js')).toBe(false);
+		expect(isWindowsForegroundDevScript('astro dev &')).toBe(false);
+		expect(isWindowsForegroundDevScript('astro dev | tee dev.log')).toBe(false);
+		expect(isWindowsForegroundDevScript('astro dev $(node daemonize.js)')).toBe(false);
 	});
 });
 

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -1,0 +1,221 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+	collectInstalledDependencyNames,
+	detectPackageManager,
+	discoverAstroWorkspacePackages,
+	resolveInstalledPackageManifest,
+	installedAstroMajor,
+} from '../src/runtime.js';
+
+const temporaryRoots: string[] = [];
+type PackageManager = 'pnpm' | 'yarn' | 'bun' | 'npm';
+
+async function temporaryRoot(): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), 'every-astro-test-'));
+	temporaryRoots.push(root);
+	return root;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+	await mkdir(join(path, '..'), { recursive: true });
+	await writeFile(path, `${JSON.stringify(value, null, '\t')}\n`);
+}
+
+async function createProject(manifest: Record<string, unknown> = {}): Promise<string> {
+	const root = await temporaryRoot();
+	await writeJson(join(root, 'package.json'), { name: 'test-project', ...manifest });
+	return root;
+}
+
+async function writePackage(
+	root: string,
+	directory: string,
+	manifest: Record<string, unknown>
+): Promise<void> {
+	await writeJson(join(root, directory, 'package.json'), manifest);
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+	);
+});
+
+describe('installedAstroMajor', () => {
+	test('reads the major version from the Astro package resolved by the project', async () => {
+		const project = await createProject({ dependencies: { astro: '^7.2.1' } });
+		await writePackage(project, 'node_modules/astro', { name: 'astro', version: '7.2.1' });
+
+		await expect(installedAstroMajor(project)).resolves.toBe(7);
+	});
+});
+
+describe('detectPackageManager', () => {
+	test('prefers a valid packageManager declaration over lockfiles', async () => {
+		const project = await createProject({ packageManager: 'yarn@4.6.0' });
+		await writeFile(join(project, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+
+		await expect(detectPackageManager(project)).resolves.toBe('yarn');
+	});
+
+	test.each([
+		['pnpm-lock.yaml', 'pnpm'],
+		['yarn.lock', 'yarn'],
+		['bun.lock', 'bun'],
+		['package-lock.json', 'npm'],
+	] as const)(
+		'detects %s when no packageManager is declared',
+		async (lockfile: string, manager: PackageManager) => {
+			const project = await createProject();
+			await writeFile(join(project, lockfile), 'fixture\n');
+
+			await expect(detectPackageManager(project)).resolves.toBe(manager);
+		}
+	);
+});
+
+describe('discoverAstroWorkspacePackages', () => {
+	test('finds public Astro and scoped Astro packages but excludes private and unrelated packages', async () => {
+		const repository = await temporaryRoot();
+		await writePackage(repository, 'packages/astro', { name: 'astro', version: '7.0.0' });
+		await writePackage(repository, 'packages/compiler', {
+			name: '@astrojs/compiler',
+			version: '2.0.0',
+		});
+		await writePackage(repository, 'packages/node', { name: '@astrojs/node', version: '9.0.0' });
+		await writePackage(repository, 'packages/internal', {
+			name: '@astrojs/internal',
+			private: true,
+		});
+		await writePackage(repository, 'packages/unrelated', { name: 'unrelated-package' });
+
+		await expect(discoverAstroWorkspacePackages(repository)).resolves.toEqual(
+			new Map([
+				['astro', join(repository, 'packages/astro')],
+				['@astrojs/compiler', join(repository, 'packages/compiler')],
+				['@astrojs/node', join(repository, 'packages/node')],
+			])
+		);
+	});
+});
+
+describe('collectInstalledDependencyNames', () => {
+	test('walks scoped direct dependencies and their transitive package manifests', async () => {
+		const project = await createProject({
+			dependencies: { '@scope/direct': '1.0.0' },
+			devDependencies: { astro: '7.0.0' },
+		});
+		await writePackage(project, 'node_modules/@scope/direct', {
+			name: '@scope/direct',
+			version: '1.0.0',
+			dependencies: { 'plain-transitive': '1.0.0' },
+		});
+		await writePackage(project, 'node_modules/plain-transitive', {
+			name: 'plain-transitive',
+			version: '1.0.0',
+			optionalDependencies: { '@scope/nested': '1.0.0' },
+		});
+		await writePackage(project, 'node_modules/@scope/nested', {
+			name: '@scope/nested',
+			version: '1.0.0',
+		});
+		await writePackage(project, 'node_modules/astro', { name: 'astro', version: '7.0.0' });
+		await writePackage(project, 'node_modules/unreachable', {
+			name: 'unreachable',
+			version: '1.0.0',
+		});
+
+		await expect(collectInstalledDependencyNames(project)).resolves.toEqual(
+			new Set(['@scope/direct', 'plain-transitive', '@scope/nested', 'astro'])
+		);
+	});
+
+	test('walks peers from packages that export only a subpath', async () => {
+		const project = await createProject({
+			dependencies: { 'subpath-only': '1.0.0' },
+		});
+		await writePackage(project, 'node_modules/subpath-only', {
+			name: 'subpath-only',
+			version: '1.0.0',
+			exports: { './runtime': './dist/runtime.js' },
+			peerDependencies: { astro: '7.0.0', '@astrojs/node': '9.0.0' },
+		});
+		await writePackage(project, 'node_modules/astro', {
+			name: 'astro',
+			version: '7.0.0',
+			exports: { './cli': './dist/cli.js' },
+			peerDependencies: { '@astrojs/compiler': '2.0.0' },
+		});
+		await writePackage(project, 'node_modules/@astrojs/node', {
+			name: '@astrojs/node',
+			version: '9.0.0',
+			exports: { './adapter': './dist/adapter.js' },
+		});
+		await writePackage(project, 'node_modules/@astrojs/compiler', {
+			name: '@astrojs/compiler',
+			version: '2.0.0',
+			exports: { './sync': './dist/sync.js' },
+		});
+
+		await expect(installedAstroMajor(project)).resolves.toBe(7);
+		await expect(collectInstalledDependencyNames(project)).resolves.toEqual(
+			new Set(['subpath-only', '@astrojs/node', 'astro', '@astrojs/compiler'])
+		);
+	});
+	test('follows pnpm store manifests through a symlinked package', async () => {
+		const project = await createProject({
+			dependencies: { direct: '1.0.0', astro: '7.0.0' },
+		});
+		const storePackage = 'node_modules/.pnpm/direct@1.0.0/node_modules/direct';
+		await writePackage(project, storePackage, {
+			name: 'direct',
+			version: '1.0.0',
+			exports: { './runtime': './dist/runtime.js' },
+			dependencies: { nested: '1.0.0' },
+		});
+		await writePackage(project, 'node_modules/.pnpm/direct@1.0.0/node_modules/nested', {
+			name: 'nested',
+			version: '1.0.0',
+		});
+		await writePackage(project, 'node_modules/astro', { name: 'astro', version: '7.0.0' });
+		await symlink(join(project, storePackage), join(project, 'node_modules/direct'), 'dir');
+
+		await expect(collectInstalledDependencyNames(project)).resolves.toEqual(
+			new Set(['astro', 'direct', 'nested'])
+		);
+	});
+});
+
+describe('resolveInstalledPackageManifest', () => {
+	test('loads and caches the target project PnP API before resolving packages', async () => {
+		const project = await createProject();
+		const packageRoot = join(project, '.yarn/cache/astro');
+		const marker = `__everyAstroPnpSetup${temporaryRoots.length}`;
+		await writePackage(project, '.yarn/cache/astro', { name: 'astro', version: '7.0.0' });
+		await writeFile(
+			join(project, '.pnp.cjs'),
+			[
+				`const packageRoot = ${JSON.stringify(packageRoot)};`,
+				`const marker = ${JSON.stringify(marker)};`,
+				'exports.setup = () => { globalThis[marker] = (globalThis[marker] ?? 0) + 1; };',
+				'exports.resolveToUnqualified = (request) => {',
+				'\tif (!globalThis[marker]) throw new Error("PnP setup was not called");',
+				'\treturn request === "astro" ? packageRoot : null;',
+				'};',
+				'',
+			].join('\n')
+		);
+
+		await expect(resolveInstalledPackageManifest('astro', project)).resolves.toBe(
+			join(packageRoot, 'package.json')
+		);
+		await expect(resolveInstalledPackageManifest('astro', project)).resolves.toBe(
+			join(packageRoot, 'package.json')
+		);
+		expect((globalThis as Record<string, unknown>)[marker]).toBe(1);
+		delete (globalThis as Record<string, unknown>)[marker];
+	});
+});

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -1,22 +1,30 @@
-import { mkdir, mkdtemp, readlink, rm, symlink, writeFile } from 'node:fs/promises';
+import { spawn as spawnChild } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdir, mkdtemp, readlink, readdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
 import {
 	abortError,
 	collectInstalledDependencyNames,
+	collectAstroWorkspacePackageClosure,
 	createRuntimeDependencies,
+	determineBisectProgress,
 	dependencySymlinkType,
 	detectPackageManager,
+	detectPackageManagerRoot,
 	discoverAstroWorkspacePackages,
 	installedAstroMajor,
 	isolatedBootstrapEnvironment,
 	linkBunPackage,
 	packageLinkCommands,
+	parseBisectCompletion,
 	resolveInstalledPackageManifest,
 	restoreDependencySymlink,
 	selectLatestAstroReleaseTag,
 	selectLatestAstroReleaseRevision,
+	selectLatestAstroRevision,
+	terminateChildProcess,
 } from '../src/runtime.js';
 
 const temporaryRoots: string[] = [];
@@ -45,6 +53,29 @@ async function writePackage(
 	manifest: Record<string, unknown>
 ): Promise<void> {
 	await writeJson(join(root, directory, 'package.json'), manifest);
+}
+
+async function runCommand(
+	command: string,
+	args: string[],
+	cwd: string,
+	environment: NodeJS.ProcessEnv = {}
+): Promise<string> {
+	const child = spawnChild(command, args, {
+		cwd,
+		env: { ...process.env, ...environment },
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	let output = '';
+	child.stdout.on('data', (chunk: Buffer) => {
+		output += chunk;
+	});
+	child.stderr.on('data', (chunk: Buffer) => {
+		output += chunk;
+	});
+	const [exitCode] = (await once(child, 'close')) as [number | null];
+	if (exitCode !== 0) throw new Error(`${command} ${args.join(' ')} failed:\n${output}`);
+	return output;
 }
 
 afterEach(async () => {
@@ -81,6 +112,30 @@ describe('selectLatestAstroReleaseTag', () => {
 	test('selects the commit revision rather than a tag object for bisecting', () => {
 		expect(selectLatestAstroReleaseRevision(['astro@7.4.3'], 7)).toBe('astro@7.4.3^{commit}');
 	});
+	test('uses clone HEAD when it remains in the installed major', () => {
+		expect(selectLatestAstroRevision(['astro@7.4.3'], 7, '7.5.0-dev.1')).toBe('HEAD');
+		expect(selectLatestAstroRevision(['astro@7.4.3'], 7, '8.0.0')).toBe('astro@7.4.3^{commit}');
+	});
+
+	test('parses quoted and unquoted Git bisect completion revisions', () => {
+		expect(parseBisectCompletion('abc1234 is the first bad commit')).toBe('abc1234');
+		expect(parseBisectCompletion('"abcdef0123456789" is the first bad commit')).toBe(
+			'abcdef0123456789'
+		);
+		expect(parseBisectCompletion("abcdef0123456789 is the first 'bad' commit")).toBe(
+			'abcdef0123456789'
+		);
+		expect(parseBisectCompletion('bisecting: 4 revisions left')).toBeUndefined();
+	});
+
+	test('fails rather than repeating an unchanged revision on unknown bisect output', () => {
+		expect(() => determineBisectProgress('before', 'before', 'unrecognized completion')).toThrow(
+			'Could not determine Git bisect progress'
+		);
+		expect(
+			determineBisectProgress('before', 'after', 'bisecting: 4 revisions left')
+		).toBeUndefined();
+	});
 });
 
 describe('abortError', () => {
@@ -95,7 +150,36 @@ describe('abortError', () => {
 	});
 });
 
+describe('terminateChildProcess', () => {
+	test.skipIf(process.platform === 'win32')(
+		'waits for the detached process group instead of only the leader',
+		async () => {
+			const child = spawnChild('sh', ['-c', 'sleep 30 & wait'], {
+				detached: true,
+				stdio: 'ignore',
+			});
+			await once(child, 'spawn');
+			const pid = child.pid!;
+
+			await terminateChildProcess(child, process.platform, 500);
+
+			expect(() => process.kill(-pid, 0)).toThrow(/ESRCH/);
+		}
+	);
+});
+
 describe('detectPackageManager', () => {
+	test('uses the ancestor Yarn workspace lockfile root for a nested declaration', async () => {
+		const workspace = await createProject({ private: true });
+		const project = join(workspace, 'apps', 'astro-project');
+		await writeJson(join(project, 'package.json'), {
+			name: 'astro-project',
+			packageManager: 'yarn@4.6.0',
+		});
+		await writeFile(join(workspace, 'yarn.lock'), 'fixture\n');
+
+		await expect(detectPackageManagerRoot(project)).resolves.toBe(workspace);
+	});
 	test('prefers a valid packageManager declaration over lockfiles', async () => {
 		const project = await createProject({ packageManager: 'yarn@4.6.0' });
 		await writeFile(join(project, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
@@ -130,6 +214,18 @@ describe('packageLinkCommands', () => {
 		expect(packageLinkCommands('bun', false, project, links)).toEqual([]);
 	});
 
+	test('keeps checkout directory paths for pnpm linking', () => {
+		const project = '/project';
+		const links = [
+			{ name: 'astro', path: '/checkout/packages/astro' },
+			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler' },
+		];
+
+		expect(packageLinkCommands('pnpm', false, project, links)).toEqual(
+			links.map(({ path }) => ({ command: ['pnpm', 'link', path], cwd: project }))
+		);
+	});
+
 	test('replaces Bun-installed packages with the checked-out revision', async () => {
 		const project = await createProject({ dependencies: { astro: '7.0.0' } });
 		const revision = await temporaryRoot();
@@ -147,11 +243,11 @@ describe('packageLinkCommands', () => {
 		await expect(installedAstroMajor(project)).resolves.toBe(0);
 	});
 
-	test('uses the Classic Yarn link protocol entirely from the target project', () => {
+	test('uses publish-shaped file descriptors for Classic Yarn packages', () => {
 		const project = '/project';
 		const links = [
-			{ name: 'astro', path: '/checkout/packages/astro' },
-			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler' },
+			{ name: 'astro', path: '/checkout/packages/astro-7.0.0.tgz' },
+			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler-2.0.0.tgz' },
 		];
 
 		expect(packageLinkCommands('yarn', false, project, links)).toEqual([
@@ -161,18 +257,18 @@ describe('packageLinkCommands', () => {
 					'add',
 					'--pure-lockfile',
 					'--ignore-workspace-root-check',
-					...links.map(({ path }) => `link:${path}`),
+					...links.map(({ name, path }) => `${name}@file:${path}`),
 				],
 				cwd: project,
 			},
 		]);
 	});
 
-	test('uses portal dependencies for Yarn Berry packages in pnpm workspaces', () => {
+	test('uses publish-shaped file descriptors for Yarn Berry packages', () => {
 		const project = '/project';
 		const links = [
-			{ name: 'astro', path: '/checkout/packages/astro' },
-			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler' },
+			{ name: 'astro', path: '/checkout/packages/astro-7.0.0.tgz' },
+			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler-2.0.0.tgz' },
 		];
 
 		expect(packageLinkCommands('yarn', true, project, links)).toEqual([
@@ -180,12 +276,89 @@ describe('packageLinkCommands', () => {
 				command: [
 					'yarn',
 					'add',
-					'astro@portal:/checkout/packages/astro',
-					'@astrojs/compiler@portal:/checkout/packages/compiler',
+					'astro@file:/checkout/packages/astro-7.0.0.tgz',
+					'@astrojs/compiler@file:/checkout/packages/compiler-2.0.0.tgz',
 				],
 				cwd: project,
 			},
 		]);
+	});
+});
+
+describe('packed workspace package activation', () => {
+	test('activates a workspace-protocol graph with npm and Yarn PnP without network access', async () => {
+		const workspace = await temporaryRoot();
+		const helper = join(workspace, 'packages/helper');
+		const astro = join(workspace, 'packages/astro');
+		const archives = join(workspace, 'archives');
+		await writeJson(join(workspace, 'package.json'), { name: 'workspace', private: true });
+		await writeFile(join(workspace, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
+		await writePackage(workspace, 'packages/helper', {
+			name: '@astrojs/helper',
+			version: '1.0.0',
+			main: 'index.js',
+		});
+		await writeFile(join(helper, 'index.js'), 'module.exports = "local helper";\n');
+		await writePackage(workspace, 'packages/astro', {
+			name: 'astro',
+			version: '7.0.0',
+			main: 'index.js',
+			dependencies: { '@astrojs/helper': 'workspace:*' },
+		});
+		await writeFile(join(astro, 'index.js'), 'module.exports = require("@astrojs/helper");\n');
+		await runCommand('pnpm', ['install', '--offline'], workspace);
+		await mkdir(archives, { recursive: true });
+		await runCommand('pnpm', ['pack', '--pack-destination', archives], helper);
+		await runCommand('pnpm', ['pack', '--pack-destination', archives], astro);
+		const packedArchives = (await readdir(archives)).map((archive) => join(archives, archive));
+		const astroArchive = packedArchives.find((archive) => archive.endsWith('astro-7.0.0.tgz'))!;
+		const helperArchive = packedArchives.find((archive) =>
+			archive.endsWith('astrojs-helper-1.0.0.tgz')
+		)!;
+
+		const npmProject = await createProject();
+		await runCommand(
+			'npm',
+			['install', '--offline', '--no-save', '--package-lock=false', helperArchive, astroArchive],
+			npmProject
+		);
+		await expect(
+			runCommand(
+				process.execPath,
+				['-e', 'process.exit(require("astro") === "local helper" ? 0 : 1)'],
+				npmProject
+			)
+		).resolves.toBe('');
+
+		const yarnProject = await createProject({ packageManager: 'yarn@4.17.1' });
+		await writeFile(join(yarnProject, '.yarnrc.yml'), 'nodeLinker: pnp\n');
+		await writeJson(join(yarnProject, 'package.json'), {
+			name: 'test-project',
+			packageManager: 'yarn@4.17.1',
+			resolutions: {
+				'@astrojs/helper': `file:${helperArchive}`,
+				astro: `file:${astroArchive}`,
+			},
+		});
+		await runCommand(
+			'yarn',
+			[
+				'add',
+				'--mode=skip-build',
+				`@astrojs/helper@file:${helperArchive}`,
+				`astro@file:${astroArchive}`,
+			],
+			yarnProject,
+			{ YARN_ENABLE_NETWORK: '0' }
+		);
+		await expect(
+			runCommand(
+				'yarn',
+				['node', '-e', 'process.exit(require("astro") === "local helper" ? 0 : 1)'],
+				yarnProject,
+				{ YARN_ENABLE_NETWORK: '0' }
+			)
+		).resolves.toBe('');
 	});
 });
 
@@ -275,6 +448,29 @@ describe('discoverAstroWorkspacePackages', () => {
 				['astro', join(repository, 'packages/astro')],
 				['@astrojs/compiler', join(repository, 'packages/compiler')],
 				['@astrojs/node', join(repository, 'packages/node')],
+			])
+		);
+	});
+
+	test('includes workspace-protocol dependencies introduced by the checked-out revision', async () => {
+		const repository = await temporaryRoot();
+		await writePackage(repository, 'packages/astro', {
+			name: 'astro',
+			version: '7.0.0',
+			dependencies: { '@astrojs/new-helper': 'workspace:*' },
+		});
+		await writePackage(repository, 'packages/new-helper', {
+			name: '@astrojs/new-helper',
+			version: '1.0.0',
+		});
+		const packages = await discoverAstroWorkspacePackages(repository);
+
+		await expect(
+			collectAstroWorkspacePackageClosure(packages, new Set(['astro']))
+		).resolves.toEqual(
+			new Map([
+				['astro', join(repository, 'packages/astro')],
+				['@astrojs/new-helper', join(repository, 'packages/new-helper')],
 			])
 		);
 	});
@@ -395,5 +591,23 @@ describe('resolveInstalledPackageManifest', () => {
 		);
 		expect((globalThis as Record<string, unknown>)[marker]).toBe(1);
 		delete (globalThis as Record<string, unknown>)[marker];
+	});
+
+	test('discovers a nearest Yarn Classic .pnp.js API', async () => {
+		const project = await createProject();
+		const packageRoot = join(project, '.cache/astro');
+		await writePackage(project, '.cache/astro', { name: 'astro', version: '7.0.0' });
+		await writeFile(
+			join(project, '.pnp.js'),
+			[
+				`const packageRoot = ${JSON.stringify(packageRoot)};`,
+				'exports.resolveToUnqualified = (request) => request === "astro" ? packageRoot : null;',
+				'',
+			].join('\n')
+		);
+
+		await expect(resolveInstalledPackageManifest('astro', project)).resolves.toBe(
+			join(packageRoot, 'package.json')
+		);
 	});
 });

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -13,6 +13,7 @@ import {
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { setTimeout as delay } from 'node:timers/promises';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
@@ -63,6 +64,18 @@ async function createProject(manifest: Record<string, unknown> = {}): Promise<st
 	const root = await temporaryRoot();
 	await writeJson(join(root, 'package.json'), { name: 'test-project', ...manifest });
 	return root;
+}
+
+async function createPnpArchiveProject(): Promise<string> {
+	const project = await createProject({ dependencies: { astro: '7.0.0' } });
+	const packageRoot = join(project, '.yarn/cache/astro.zip/node_modules/astro');
+	await mkdir(join(project, '.yarn/cache'), { recursive: true });
+	await writeFile(join(project, '.yarn/cache/astro.zip'), '');
+	await writeFile(
+		join(project, '.pnp.cjs'),
+		`exports.resolveToUnqualified = (request) => request === 'astro' ? ${JSON.stringify(packageRoot)} : null;\n`
+	);
+	return project;
 }
 
 async function writePackage(
@@ -312,6 +325,134 @@ test.skipIf(process.platform === 'win32')(
 		}
 	}
 );
+
+test('keeps a nonzero PnP reader stderr failure ahead of termination cleanup failure', async () => {
+	const project = await createPnpArchiveProject();
+	const stderr = new PassThrough();
+	const reader = Object.assign(new EventEmitter(), {
+		stdout: new PassThrough(),
+		stderr,
+	}) as unknown as ChildProcess;
+	const cleanupError = new Error('could not terminate PnP reader');
+	const launch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		observe?.(reader);
+		process.nextTick(() => {
+			stderr.write('complete Corepack stderr');
+			reader.emit('exit', 1);
+			reader.emit('close', 1);
+		});
+		return reader;
+	};
+
+	let failure: unknown;
+	try {
+		await resolveInstalledPackageManifest(
+			'astro',
+			project,
+			undefined,
+			undefined,
+			launch,
+			async () => {
+				throw cleanupError;
+			}
+		);
+	} catch (error) {
+		failure = error;
+	}
+
+	expect(failure).toBeInstanceOf(AggregateError);
+	const aggregate = failure as AggregateError;
+	expect(aggregate.message).toBe('Could not read a PnP manifest and clean up its reader');
+	expect(aggregate.cause).toBe(aggregate.errors[0]);
+	expect(aggregate.errors[0]).toMatchObject({
+		message: expect.stringContaining('complete Corepack stderr'),
+	});
+	expect(aggregate.errors[1]).toBe(cleanupError);
+});
+
+test('keeps a malformed PnP manifest ahead of temporary-root cleanup failure', async () => {
+	const project = await createPnpArchiveProject();
+	const stdout = new PassThrough();
+	const reader = Object.assign(new EventEmitter(), {
+		stdout,
+		stderr: new PassThrough(),
+	}) as unknown as ChildProcess;
+	const cleanupError = new Error('could not remove PnP temporary root');
+	const launch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		observe?.(reader);
+		process.nextTick(() => {
+			stdout.write('not JSON');
+			reader.emit('exit', 0);
+			reader.emit('close', 0);
+		});
+		return reader;
+	};
+
+	let failure: unknown;
+	try {
+		await resolveInstalledPackageManifest(
+			'astro',
+			project,
+			undefined,
+			undefined,
+			launch,
+			async () => undefined,
+			async () => '/injected-pnp-temporary-root',
+			async () => {
+				throw cleanupError;
+			}
+		);
+	} catch (error) {
+		failure = error;
+	}
+
+	expect(failure).toBeInstanceOf(AggregateError);
+	const aggregate = failure as AggregateError;
+	expect(aggregate.message).toBe('Could not read a PnP manifest and clean up its reader');
+	expect(aggregate.cause).toBe(aggregate.errors[0]);
+	expect(aggregate.errors[0]).toBeInstanceOf(SyntaxError);
+	expect(aggregate.errors[1]).toBe(cleanupError);
+});
+
+test('owns an injected PnP launch failure before its error event fires', async () => {
+	const project = await createPnpArchiveProject();
+	const reader = Object.assign(new EventEmitter(), {
+		stdout: new PassThrough(),
+		stderr: new PassThrough(),
+	}) as unknown as ChildProcess;
+	const launchError = new Error('missing Corepack reader executable');
+	const terminate = vi.fn(async () => {
+		reader.emit('close', null);
+	});
+	const launch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		observe?.(reader);
+		process.nextTick(() => reader.emit('error', launchError));
+		return reader;
+	};
+
+	await expect(
+		resolveInstalledPackageManifest('astro', project, undefined, undefined, launch, terminate)
+	).rejects.toBe(launchError);
+	expect(terminate).toHaveBeenCalledExactlyOnceWith(reader);
+});
 
 describe('selectLatestAstroReleaseTag', () => {
 	test('selects the newest stable tag within the installed Astro major', () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -387,7 +387,7 @@ test.skipIf(process.platform !== 'win32')(
 	'launches a target through the Job Object supervisor and removes its control file',
 	async () => {
 		const root = await temporaryRoot();
-		const toolRoot = join(root, 'tool path');
+		const toolRoot = join(root, 'tool path café');
 		const batchFile = join(toolRoot, 'runner.cmd');
 		const controlFile = join(root, 'command.json');
 		await mkdir(toolRoot);
@@ -396,7 +396,7 @@ test.skipIf(process.platform !== 'win32')(
 			controlFile,
 			JSON.stringify({
 				file: batchFile,
-				args: ['spaced argument', '%literal%', 'a&b'],
+				args: ['spaced argument', 'café', '%literal%', 'a&b'],
 			})
 		);
 		const [file, ...args] = windowsJobSupervisorCommand(controlFile);

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -1,10 +1,12 @@
-import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readlink, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
 import {
+	abortError,
 	collectInstalledDependencyNames,
 	createRuntimeDependencies,
+	dependencySymlinkType,
 	detectPackageManager,
 	discoverAstroWorkspacePackages,
 	installedAstroMajor,
@@ -12,6 +14,9 @@ import {
 	linkBunPackage,
 	packageLinkCommands,
 	resolveInstalledPackageManifest,
+	restoreDependencySymlink,
+	selectLatestAstroReleaseTag,
+	selectLatestAstroReleaseRevision,
 } from '../src/runtime.js';
 
 const temporaryRoots: string[] = [];
@@ -54,6 +59,39 @@ describe('installedAstroMajor', () => {
 		await writePackage(project, 'node_modules/astro', { name: 'astro', version: '7.2.1' });
 
 		await expect(installedAstroMajor(project)).resolves.toBe(7);
+	});
+});
+
+describe('selectLatestAstroReleaseTag', () => {
+	test('selects the newest stable tag within the installed Astro major', () => {
+		expect(
+			selectLatestAstroReleaseTag(
+				['astro@8.0.0', 'astro@7.4.1', 'astro@7.5.0-rc.1', 'astro@7.4.3', 'not-an-astro-tag'],
+				7
+			)
+		).toBe('astro@7.4.3');
+	});
+
+	test('fails clearly when the installed major has no stable release tag', () => {
+		expect(() => selectLatestAstroReleaseTag(['astro@8.0.0', 'astro@7.5.0-rc.1'], 7)).toThrow(
+			'Could not find a stable Astro 7 release tag'
+		);
+	});
+
+	test('selects the commit revision rather than a tag object for bisecting', () => {
+		expect(selectLatestAstroReleaseRevision(['astro@7.4.3'], 7)).toBe('astro@7.4.3^{commit}');
+	});
+});
+
+describe('abortError', () => {
+	test('uses the standard abort error name', () => {
+		const controller = new AbortController();
+		controller.abort('cancelled by user');
+
+		expect(abortError(controller.signal)).toMatchObject({
+			name: 'AbortError',
+			message: 'Operation aborted: cancelled by user',
+		});
 	});
 });
 
@@ -151,6 +189,35 @@ describe('packageLinkCommands', () => {
 	});
 });
 
+describe('restoreDependencySymlink', () => {
+	test('restores the saved directory link target', async () => {
+		const project = await createProject({ dependencies: { astro: '7.0.0' } });
+		const originalPackage = join(project, 'packages', 'original-astro');
+		const replacementPackage = join(project, 'packages', 'replacement-astro');
+		const packagePath = join(project, 'node_modules', 'astro');
+		await writePackage(project, 'packages/original-astro', { name: 'astro', version: '7.0.0' });
+		await writePackage(project, 'packages/replacement-astro', {
+			name: 'astro',
+			version: '0.0.0-revision',
+		});
+		await mkdir(join(project, 'node_modules'), { recursive: true });
+		await symlink(replacementPackage, packagePath, 'dir');
+
+		await restoreDependencySymlink({
+			path: packagePath,
+			target: originalPackage,
+			type: 'dir',
+		});
+
+		await expect(readlink(packagePath)).resolves.toBe(originalPackage);
+		await expect(installedAstroMajor(project)).resolves.toBe(7);
+	});
+
+	test('uses junctions for Windows directory links', () => {
+		expect(dependencySymlinkType('win32')).toBe('junction');
+	});
+});
+
 describe('isolatedBootstrapEnvironment', () => {
 	test('removes consumer Node loader hooks without changing other environment values', () => {
 		expect(
@@ -159,6 +226,17 @@ describe('isolatedBootstrapEnvironment', () => {
 				COREPACK_HOME: '/cache/corepack',
 			})
 		).toEqual({ COREPACK_HOME: '/cache/corepack' });
+	});
+
+	test('preserves unrelated Node options while removing all loader hook forms', () => {
+		expect(
+			isolatedBootstrapEnvironment({
+				NODE_OPTIONS:
+					'--max-old-space-size=4096 --require "/project/.pnp.cjs" -r=./register.cjs --import "./instrumentation.mjs" --loader=./loader.mjs --experimental-loader "./legacy loader.mjs" --conditions="development test" --trace-warnings',
+			})
+		).toEqual({
+			NODE_OPTIONS: '--max-old-space-size=4096 --conditions="development test" --trace-warnings',
+		});
 	});
 });
 

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -745,6 +745,13 @@ describe('packed workspace package activation', () => {
 					{ YARN_ENABLE_NETWORK: '0' }
 				)
 			).resolves.toBe('');
+			const astroManifest = await resolveInstalledPackageManifest('astro', yarnProject);
+
+			expect(astroManifest).toMatch(/\.zip[\\/]node_modules[\\/]astro[\\/]package\.json$/);
+			await expect(installedAstroMajor(yarnProject)).resolves.toBe(7);
+			await expect(collectInstalledDependencyNames(yarnProject)).resolves.toEqual(
+				new Set(['astro', '@astrojs/helper'])
+			);
 		}
 	);
 });
@@ -788,30 +795,84 @@ describe('isolatedBootstrapEnvironment', () => {
 		).toEqual({ COREPACK_HOME: '/cache/corepack' });
 	});
 
-	test('removes loader hooks while preserving raw surrounding whitespace', async () => {
+	test('removes loaders after quoted tabs and newlines while preserving raw retained tokens', async () => {
 		const nodeOptions =
-			'  --trace-warnings --require "./project hook.cjs"  --conditions="development test"  ';
+			'--conditions="line\tbreak\nstill" --require "./project hook.cjs" --trace-warnings';
 		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
 
 		expect(environment).toEqual({
-			NODE_OPTIONS: '  --trace-warnings    --conditions="development test"  ',
+			NODE_OPTIONS: '--conditions="line\tbreak\nstill"   --trace-warnings',
 		});
 		await expect(
 			runCommand(process.execPath, ['--version'], process.cwd(), environment)
 		).resolves.toMatch(/^v/);
 	});
 
-	test('preserves a no-loader Node options string byte-for-byte', async () => {
-		const nodeOptions = '  --conditions="foo\\" bar"   --trace-warnings  ';
-		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
+	test('removes loaders whose names concatenate escaped double-quoted segments', async () => {
+		const environment = isolatedBootstrapEnvironment({
+			NODE_OPTIONS: '--requ"\\i"re "./project hook.cjs" --trace-warnings',
+		});
 
-		expect(environment).toEqual({ NODE_OPTIONS: nodeOptions });
+		expect(environment).toEqual({ NODE_OPTIONS: '  --trace-warnings' });
 		await expect(
 			runCommand(process.execPath, ['--version'], process.cwd(), environment)
 		).resolves.toMatch(/^v/);
 	});
 
-	test('removes a loader after an unmatched literal single quote', async () => {
+	test.each([
+		[
+			'require equals',
+			'--require="./project hook.cjs"',
+			'--trace-warnings  --conditions=development',
+		],
+		[
+			'import separate',
+			'--import "./project hook.cjs"',
+			'--trace-warnings   --conditions=development',
+		],
+		[
+			'loader equals',
+			'--loader="./project hook.cjs"',
+			'--trace-warnings  --conditions=development',
+		],
+		[
+			'experimental loader separate',
+			'--experimental-loader "./project hook.cjs"',
+			'--trace-warnings   --conditions=development',
+		],
+		[
+			'underscored experimental loader equals',
+			'--experimental_loader="./project hook.cjs"',
+			'--trace-warnings  --conditions=development',
+		],
+	])('removes valid %s syntax', async (_name, loaderOption, expectedNodeOptions) => {
+		const environment = isolatedBootstrapEnvironment({
+			NODE_OPTIONS: `--trace-warnings ${loaderOption} --conditions=development`,
+		});
+
+		expect(environment).toEqual({
+			NODE_OPTIONS: expectedNodeOptions,
+		});
+		await expect(
+			runCommand(process.execPath, ['--version'], process.cwd(), environment)
+		).resolves.toMatch(/^v/);
+	});
+
+	test.each([
+		['missing operand', '--require'],
+		['option operand', '--import --trace-warnings'],
+		['empty long equals value', '--loader=""'],
+		['invalid short equals form', '-r=./project-hook.cjs'],
+	])('preserves malformed loader syntax for Node to reject: %s', async (_name, nodeOptions) => {
+		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
+
+		expect(environment).toEqual({ NODE_OPTIONS: nodeOptions });
+		await expect(
+			runCommand(process.execPath, ['--version'], process.cwd(), environment)
+		).rejects.toThrow(/not allowed in NODE_OPTIONS|requires an argument/);
+	});
+
+	test('preserves literal single quotes and removes a later real loader', async () => {
 		const environment = isolatedBootstrapEnvironment({
 			NODE_OPTIONS: "--conditions='foo --require ./project-hook.cjs --trace-warnings",
 		});
@@ -822,8 +883,8 @@ describe('isolatedBootstrapEnvironment', () => {
 		).resolves.toMatch(/^v/);
 	});
 
-	test('preserves single-quoted loader names without classifying them as hooks', async () => {
-		const nodeOptions = "'--require' ./project-hook.cjs --trace-warnings";
+	test('preserves exact no-loader whitespace and single-quoted tokens', async () => {
+		const nodeOptions = `  --conditions="foo\\" bar"   '--require' ./project-hook.cjs  `;
 		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
 
 		expect(environment).toEqual({ NODE_OPTIONS: nodeOptions });
@@ -845,7 +906,7 @@ describe('isolatedBootstrapEnvironment', () => {
 		).rejects.toThrow('not allowed in NODE_OPTIONS');
 	});
 
-	test('preserves malformed Node options for Node to reject', async () => {
+	test('preserves malformed double-quoted Node options for Node to reject', async () => {
 		const nodeOptions = '--conditions="unterminated';
 		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
 
@@ -1009,19 +1070,15 @@ describe('collectInstalledDependencyNames', () => {
 });
 
 describe('resolveInstalledPackageManifest', () => {
-	test('loads and caches the target project PnP API before resolving packages', async () => {
+	test('loads the target project PnP API without globally installing it', async () => {
 		const project = await createProject();
 		const packageRoot = join(project, '.yarn/cache/astro');
-		const marker = `__everyAstroPnpSetup${temporaryRoots.length}`;
 		await writePackage(project, '.yarn/cache/astro', { name: 'astro', version: '7.0.0' });
 		await writeFile(
 			join(project, '.pnp.cjs'),
 			[
 				`const packageRoot = ${JSON.stringify(packageRoot)};`,
-				`const marker = ${JSON.stringify(marker)};`,
-				'exports.setup = () => { globalThis[marker] = (globalThis[marker] ?? 0) + 1; };',
 				'exports.resolveToUnqualified = (request) => {',
-				'\tif (!globalThis[marker]) throw new Error("PnP setup was not called");',
 				'\treturn request === "astro" ? packageRoot : null;',
 				'};',
 				'',
@@ -1034,8 +1091,6 @@ describe('resolveInstalledPackageManifest', () => {
 		await expect(resolveInstalledPackageManifest('astro', project)).resolves.toBe(
 			join(packageRoot, 'package.json')
 		);
-		expect((globalThis as Record<string, unknown>)[marker]).toBe(1);
-		delete (globalThis as Record<string, unknown>)[marker];
 	});
 
 	test('discovers a nearest Yarn Classic .pnp.js API', async () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -745,13 +745,20 @@ describe('packed workspace package activation', () => {
 					{ YARN_ENABLE_NETWORK: '0' }
 				)
 			).resolves.toBe('');
-			const astroManifest = await resolveInstalledPackageManifest('astro', yarnProject);
+			const previousPath = process.env.PATH;
+			process.env.PATH = join(yarnProject, 'no-bare-yarn');
+			try {
+				const astroManifest = await resolveInstalledPackageManifest('astro', yarnProject);
 
-			expect(astroManifest).toMatch(/\.zip[\\/]node_modules[\\/]astro[\\/]package\.json$/);
-			await expect(installedAstroMajor(yarnProject)).resolves.toBe(7);
-			await expect(collectInstalledDependencyNames(yarnProject)).resolves.toEqual(
-				new Set(['astro', '@astrojs/helper'])
-			);
+				expect(astroManifest).toMatch(/\.zip[\\/]node_modules[\\/]astro[\\/]package\.json$/);
+				await expect(installedAstroMajor(yarnProject)).resolves.toBe(7);
+				await expect(collectInstalledDependencyNames(yarnProject)).resolves.toEqual(
+					new Set(['astro', '@astrojs/helper'])
+				);
+			} finally {
+				if (previousPath === undefined) delete process.env.PATH;
+				else process.env.PATH = previousPath;
+			}
 		}
 	);
 });
@@ -931,6 +938,68 @@ describe('createRuntimeDependencies', () => {
 		await expect(dependencies.createSession()).rejects.toThrow(
 			'every-astro requires a npm lockfile to restore the exact dependency tree'
 		);
+	});
+
+	test('aborts and reaps the Corepack Yarn PnP manifest reader process tree', async () => {
+		const project = await createProject({
+			packageManager: 'yarn@4.17.1',
+			dependencies: { astro: '7.0.0' },
+		});
+		const pidDirectory = join(project, 'reader-pids');
+		const packageRoot = join(project, '.yarn/cache/astro.zip/node_modules/astro');
+		const previousPidDirectory = process.env.EVERY_ASTRO_PNP_READER_PIDS;
+		await mkdir(pidDirectory, { recursive: true });
+		await mkdir(join(project, '.yarn/cache'), { recursive: true });
+		await writeFile(join(project, '.yarn/cache/astro.zip'), '');
+		await writeFile(
+			join(project, '.pnp.cjs'),
+			`exports.resolveToUnqualified = (request) => request === 'astro' ? ${JSON.stringify(packageRoot)} : null;\n`
+		);
+		await writeFile(
+			join(project, '.yarnrc.yml'),
+			'yarnPath: .yarn/releases/hang.cjs\nnodeLinker: pnp\n'
+		);
+		await mkdir(join(project, '.yarn/releases'), { recursive: true });
+		// The fixture keeps the real Corepack/Yarn reader and its descendant alive until abort.
+		await writeFile(
+			join(project, '.yarn/releases/hang.cjs'),
+			[
+				"const { spawn } = require('node:child_process');",
+				"const { mkdirSync, writeFileSync } = require('node:fs');",
+				"const { join } = require('node:path');",
+				'const directory = process.env.EVERY_ASTRO_PNP_READER_PIDS;',
+				"if (!directory) throw new Error('Missing PID directory');",
+				'mkdirSync(directory, { recursive: true });',
+				"const descendant = spawn(process.execPath, ['-e', \"const { writeFileSync } = require('node:fs'); const { join } = require('node:path'); writeFileSync(join(process.env.EVERY_ASTRO_PNP_READER_PIDS, `descendant-${process.pid}`), ''); setInterval(() => {}, 1_000);\"], { stdio: 'ignore' });",
+				'descendant.unref();',
+				"writeFileSync(join(directory, `reader-${process.pid}`), '');",
+				'setInterval(() => {}, 1_000);',
+			].join('\n')
+		);
+		process.env.EVERY_ASTRO_PNP_READER_PIDS = pidDirectory;
+		const controller = new AbortController();
+		try {
+			const dependencies = createRuntimeDependencies(project, controller.signal);
+			// Filesystem readiness comes from external processes, so Vitest fake timers cannot drive it.
+			let pids: number[] = [];
+			for (let attempt = 0; attempt < 100; attempt += 1) {
+				pids = (await readdir(pidDirectory))
+					.map((entry) => Number(entry.slice(entry.lastIndexOf('-') + 1)))
+					.filter(Number.isSafeInteger);
+				if (pids.length >= 2) break;
+				await delay(10);
+			}
+			expect(pids.length).toBeGreaterThanOrEqual(2);
+
+			controller.abort('cancel PnP reader');
+			await expect(dependencies).rejects.toMatchObject({ name: 'AbortError' });
+			for (const pid of pids) {
+				expect(() => process.kill(pid, 0)).toThrow(/ESRCH/);
+			}
+		} finally {
+			if (previousPidDirectory === undefined) delete process.env.EVERY_ASTRO_PNP_READER_PIDS;
+			else process.env.EVERY_ASTRO_PNP_READER_PIDS = previousPidDirectory;
+		}
 	});
 });
 

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -529,80 +529,83 @@ describe('packageLinkCommands', () => {
 });
 
 describe('packed workspace package activation', () => {
-	test('activates a workspace-protocol graph with npm and Yarn PnP without network access', async () => {
-		const workspace = await temporaryRoot();
-		const helper = join(workspace, 'packages/helper');
-		const astro = join(workspace, 'packages/astro');
-		const archives = join(workspace, 'archives');
-		await writeJson(join(workspace, 'package.json'), { name: 'workspace', private: true });
-		await writeFile(join(workspace, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
-		await writePackage(workspace, 'packages/helper', {
-			name: '@astrojs/helper',
-			version: '1.0.0',
-			main: 'index.js',
-		});
-		await writeFile(join(helper, 'index.js'), 'module.exports = "local helper";\n');
-		await writePackage(workspace, 'packages/astro', {
-			name: 'astro',
-			version: '7.0.0',
-			main: 'index.js',
-			dependencies: { '@astrojs/helper': 'workspace:*' },
-		});
-		await writeFile(join(astro, 'index.js'), 'module.exports = require("@astrojs/helper");\n');
-		await runCommand('pnpm', ['install', '--offline'], workspace);
-		await mkdir(archives, { recursive: true });
-		await runCommand('pnpm', ['pack', '--pack-destination', archives], helper);
-		await runCommand('pnpm', ['pack', '--pack-destination', archives], astro);
-		const packedArchives = (await readdir(archives)).map((archive) => join(archives, archive));
-		const astroArchive = packedArchives.find((archive) => archive.endsWith('astro-7.0.0.tgz'))!;
-		const helperArchive = packedArchives.find((archive) =>
-			archive.endsWith('astrojs-helper-1.0.0.tgz')
-		)!;
+	test.skipIf(process.platform === 'win32')(
+		'activates a workspace-protocol graph with npm and Yarn PnP without network access',
+		async () => {
+			const workspace = await temporaryRoot();
+			const helper = join(workspace, 'packages/helper');
+			const astro = join(workspace, 'packages/astro');
+			const archives = join(workspace, 'archives');
+			await writeJson(join(workspace, 'package.json'), { name: 'workspace', private: true });
+			await writeFile(join(workspace, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
+			await writePackage(workspace, 'packages/helper', {
+				name: '@astrojs/helper',
+				version: '1.0.0',
+				main: 'index.js',
+			});
+			await writeFile(join(helper, 'index.js'), 'module.exports = "local helper";\n');
+			await writePackage(workspace, 'packages/astro', {
+				name: 'astro',
+				version: '7.0.0',
+				main: 'index.js',
+				dependencies: { '@astrojs/helper': 'workspace:*' },
+			});
+			await writeFile(join(astro, 'index.js'), 'module.exports = require("@astrojs/helper");\n');
+			await runCommand('pnpm', ['install', '--offline'], workspace);
+			await mkdir(archives, { recursive: true });
+			await runCommand('pnpm', ['pack', '--pack-destination', archives], helper);
+			await runCommand('pnpm', ['pack', '--pack-destination', archives], astro);
+			const packedArchives = (await readdir(archives)).map((archive) => join(archives, archive));
+			const astroArchive = packedArchives.find((archive) => archive.endsWith('astro-7.0.0.tgz'))!;
+			const helperArchive = packedArchives.find((archive) =>
+				archive.endsWith('astrojs-helper-1.0.0.tgz')
+			)!;
 
-		const npmProject = await createProject();
-		await runCommand(
-			'npm',
-			['install', '--offline', '--no-save', '--package-lock=false', helperArchive, astroArchive],
-			npmProject
-		);
-		await expect(
-			runCommand(
-				process.execPath,
-				['-e', 'process.exit(require("astro") === "local helper" ? 0 : 1)'],
+			const npmProject = await createProject();
+			await runCommand(
+				'npm',
+				['install', '--offline', '--no-save', '--package-lock=false', helperArchive, astroArchive],
 				npmProject
-			)
-		).resolves.toBe('');
+			);
+			await expect(
+				runCommand(
+					process.execPath,
+					['-e', 'process.exit(require("astro") === "local helper" ? 0 : 1)'],
+					npmProject
+				)
+			).resolves.toBe('');
 
-		const yarnProject = await createProject({ packageManager: 'yarn@4.17.1' });
-		await writeFile(join(yarnProject, '.yarnrc.yml'), 'nodeLinker: pnp\n');
-		await writeJson(join(yarnProject, 'package.json'), {
-			name: 'test-project',
-			packageManager: 'yarn@4.17.1',
-			resolutions: {
-				'@astrojs/helper': `file:${helperArchive}`,
-				astro: `file:${astroArchive}`,
-			},
-		});
-		await runCommand(
-			'yarn',
-			[
-				'add',
-				'--mode=skip-build',
-				`@astrojs/helper@file:${helperArchive}`,
-				`astro@file:${astroArchive}`,
-			],
-			yarnProject,
-			{ YARN_ENABLE_NETWORK: '0' }
-		);
-		await expect(
-			runCommand(
+			const yarnProject = await createProject({ packageManager: 'yarn@4.17.1' });
+			await writeFile(join(yarnProject, '.yarnrc.yml'), 'nodeLinker: pnp\n');
+			await writeJson(join(yarnProject, 'package.json'), {
+				name: 'test-project',
+				packageManager: 'yarn@4.17.1',
+				resolutions: {
+					'@astrojs/helper': `file:${helperArchive}`,
+					astro: `file:${astroArchive}`,
+				},
+			});
+			await runCommand(
 				'yarn',
-				['node', '-e', 'process.exit(require("astro") === "local helper" ? 0 : 1)'],
+				[
+					'add',
+					'--mode=skip-build',
+					`@astrojs/helper@file:${helperArchive}`,
+					`astro@file:${astroArchive}`,
+				],
 				yarnProject,
 				{ YARN_ENABLE_NETWORK: '0' }
-			)
-		).resolves.toBe('');
-	});
+			);
+			await expect(
+				runCommand(
+					'yarn',
+					['node', '-e', 'process.exit(require("astro") === "local helper" ? 0 : 1)'],
+					yarnProject,
+					{ YARN_ENABLE_NETWORK: '0' }
+				)
+			).resolves.toBe('');
+		}
+	);
 });
 
 describe('restoreDependencySymlink', () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -449,6 +449,9 @@ describe('windowsBatchCommandTail', () => {
 		expect(windowsBatchCommandTail('C:\\p\\node_modules\\.bin\\tool.cmd', ['a&b'])).toBe(
 			'/d /s /c "C:\\p\\node_modules\\.bin\\tool.cmd ^^^"a^^^&b^^^""'
 		);
+		expect(windowsBatchCommandTail('C:\\p\\node_modules\\.bin\\nested\\tool.cmd', ['a&b'])).toBe(
+			'/d /s /c "C:\\p\\node_modules\\.bin\\nested\\tool.cmd ^"a^&b^""'
+		);
 	});
 });
 

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -469,9 +469,55 @@ test.skipIf(process.platform !== 'win32')(
 				cwd: root,
 				stdio: ['ignore', 'pipe', 'pipe'],
 			});
-			await once(supervisor.stdout!, 'data');
-			const closed = once(supervisor, 'close');
-			expect(supervisor.kill()).toBe(true);
+			const runningSupervisor = supervisor;
+			const stdout = runningSupervisor.stdout!;
+			const stderr = runningSupervisor.stderr!;
+			let output = '';
+			await new Promise<void>((resolveReady, rejectReady) => {
+				let settled = false;
+				let timeout: NodeJS.Timeout | undefined;
+				const ready = () => finish();
+				const failed = (error: Error) => finish(error);
+				const closed = (exitCode: number | null) =>
+					finish(
+						new Error(
+							`Supervisor exited before readiness (exit code ${exitCode ?? 'signal'})${output ? `:\n${output}` : ''}`
+						)
+					);
+				const captureStderr = (chunk: Buffer) => {
+					output += chunk.toString();
+				};
+				const cleanup = () => {
+					clearTimeout(timeout);
+					stdout.removeListener('data', ready);
+					stderr.removeListener('data', captureStderr);
+					runningSupervisor.removeListener('error', failed);
+					runningSupervisor.removeListener('close', closed);
+				};
+				const finish = (error?: Error) => {
+					if (settled) return;
+					settled = true;
+					cleanup();
+					if (error) rejectReady(error);
+					else resolveReady();
+				};
+				stdout.once('data', ready);
+				stderr.on('data', captureStderr);
+				runningSupervisor.once('error', failed);
+				runningSupervisor.once('close', closed);
+				// This native-process readiness deadline cannot be driven by Vitest fake timers.
+				timeout = setTimeout(
+					() =>
+						finish(
+							new Error(
+								`Supervisor did not signal readiness within 2 seconds${output ? `:\n${output}` : ''}`
+							)
+						),
+					2_000
+				);
+			});
+			const closed = once(runningSupervisor, 'close');
+			expect(runningSupervisor.kill()).toBe(true);
 			await closed;
 
 			// The external descendant uses the Windows scheduler, which Vitest fake timers cannot drive.

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -245,50 +245,88 @@ describe('terminateChildProcess', () => {
 		expect(launchTaskkill).not.toHaveBeenCalled();
 	});
 
-	test('accepts a Windows taskkill race after the child exits', async () => {
-		const taskkill = new EventEmitter();
-		const launchTaskkill = vi.fn<(pid: number) => ChildProcess>(() => taskkill as ChildProcess);
-		const testChild = { pid: 4_242, exitCode: null as number | null, signalCode: null };
-		const child = testChild as ChildProcess;
-		const termination = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
-		testChild.exitCode = 0;
-		taskkill.emit('close', 1);
+	test('accepts a Windows taskkill race when the child exit is reported afterward', async () => {
+		vi.useFakeTimers();
+		try {
+			const taskkill = new EventEmitter();
+			const launchTaskkill = vi.fn<(pid: number) => ChildProcess>(() => taskkill as ChildProcess);
+			const testChild = Object.assign(new EventEmitter(), {
+				pid: 4_242,
+				exitCode: null as number | null,
+				signalCode: null,
+			});
+			const child = testChild as ChildProcess;
+			const termination = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+			taskkill.emit('close', 1);
+			await Promise.resolve();
+			setTimeout(() => {
+				testChild.exitCode = 0;
+				testChild.emit('exit', 0);
+			}, 1);
+			await vi.advanceTimersByTimeAsync(1);
 
-		await expect(termination).resolves.toBeUndefined();
-		expect(launchTaskkill).toHaveBeenCalledExactlyOnceWith(4_242);
+			await expect(termination).resolves.toBeUndefined();
+			expect(launchTaskkill).toHaveBeenCalledExactlyOnceWith(4_242);
+			expect(testChild.listenerCount('exit')).toBe(0);
+			expect(testChild.listenerCount('close')).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test('reports a Windows taskkill failure while the child is still running', async () => {
-		const child = { pid: 4_242, exitCode: null, signalCode: null } as ChildProcess;
-		const taskkill = new EventEmitter();
-		const launchTaskkill = vi.fn<(pid: number) => ChildProcess>(() => taskkill as ChildProcess);
-		const termination = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
-		taskkill.emit('close', 1);
+		vi.useFakeTimers();
+		try {
+			const child = Object.assign(new EventEmitter(), {
+				pid: 4_242,
+				exitCode: null,
+				signalCode: null,
+			}) as ChildProcess;
+			const taskkill = new EventEmitter();
+			const launchTaskkill = vi.fn<(pid: number) => ChildProcess>(() => taskkill as ChildProcess);
+			const termination = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+			taskkill.emit('close', 1);
+			await vi.advanceTimersByTimeAsync(100);
 
-		await expect(termination).rejects.toThrow(
-			'taskkill failed while terminating process 4242 (exit code 1)'
-		);
+			await expect(termination).rejects.toThrow(
+				'taskkill failed while terminating process 4242 (exit code 1)'
+			);
+			expect(child.listenerCount('exit')).toBe(0);
+			expect(child.listenerCount('close')).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test('evicts a failed Windows termination so a later cleanup retry can stop the child', async () => {
-		const child = { pid: 4_242, exitCode: null, signalCode: null } as ChildProcess;
-		const firstTaskkill = new EventEmitter();
-		const secondTaskkill = new EventEmitter();
-		const launchTaskkill = vi
-			.fn<(pid: number) => ChildProcess>()
-			.mockReturnValueOnce(firstTaskkill as ChildProcess)
-			.mockReturnValueOnce(secondTaskkill as ChildProcess);
-		const first = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
-		firstTaskkill.emit('close', 1);
+		vi.useFakeTimers();
+		try {
+			const child = Object.assign(new EventEmitter(), {
+				pid: 4_242,
+				exitCode: null,
+				signalCode: null,
+			}) as ChildProcess;
+			const firstTaskkill = new EventEmitter();
+			const secondTaskkill = new EventEmitter();
+			const launchTaskkill = vi
+				.fn<(pid: number) => ChildProcess>()
+				.mockReturnValueOnce(firstTaskkill as ChildProcess)
+				.mockReturnValueOnce(secondTaskkill as ChildProcess);
+			const first = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+			firstTaskkill.emit('close', 1);
+			await vi.advanceTimersByTimeAsync(100);
 
-		await expect(first).rejects.toThrow(
-			'taskkill failed while terminating process 4242 (exit code 1)'
-		);
-		const second = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
-		secondTaskkill.emit('close', 0);
+			await expect(first).rejects.toThrow(
+				'taskkill failed while terminating process 4242 (exit code 1)'
+			);
+			const second = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
+			secondTaskkill.emit('close', 0);
 
-		await expect(second).resolves.toBeUndefined();
-		expect(launchTaskkill).toHaveBeenCalledTimes(2);
+			await expect(second).resolves.toBeUndefined();
+			expect(launchTaskkill).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test('rejects an aborted command when termination fails and retries it during cleanup', async () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -385,44 +385,7 @@ describe('windowsJobSupervisorCommand', () => {
 });
 
 test.skipIf(process.platform !== 'win32')(
-	'forwards Unicode arguments through a Unicode batch target and removes its control file',
-	async () => {
-		const root = await temporaryRoot();
-		const toolRoot = join(root, 'tool path café');
-		const batchFile = join(toolRoot, 'runner.cmd');
-		const targetScript = join(toolRoot, 'target.mjs');
-		const argumentsFile = join(root, 'arguments.json');
-		const controlFile = join(root, 'command.json');
-		const forwarded = ['spaced argument', 'café', '%literal%', 'a&b'];
-		await mkdir(toolRoot);
-		await writeFile(
-			targetScript,
-			[
-				"import { writeFile } from 'node:fs/promises';",
-				'await writeFile(process.argv[2], JSON.stringify(process.argv.slice(3)));',
-			].join('\n')
-		);
-		await writeFile(batchFile, `@echo off\r\n"${process.execPath}" "${targetScript}" %*\r\n`);
-		await writeFile(
-			controlFile,
-			JSON.stringify({
-				file: batchFile,
-				args: [argumentsFile, ...forwarded],
-			})
-		);
-		const [file, ...args] = windowsJobSupervisorCommand(controlFile);
-		const child = spawnChild(file, args, { cwd: root, stdio: 'ignore' });
-
-		const [exitCode] = (await once(child, 'close')) as [number | null];
-
-		expect(exitCode).toBe(0);
-		await expect(readFile(argumentsFile, 'utf8').then(JSON.parse)).resolves.toEqual(forwarded);
-		await expect(readFile(controlFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
-	}
-);
-
-test.skipIf(process.platform !== 'win32')(
-	'kills a delayed descendant when the supervisor closes its Job Object',
+	'forwards Unicode arguments and kills a delayed descendant when the Job Object closes',
 	async () => {
 		const root = await temporaryRoot();
 		const toolRoot = join(root, 'job café');
@@ -431,6 +394,8 @@ test.skipIf(process.platform !== 'win32')(
 		const descendantScript = join(toolRoot, 'descendant.mjs');
 		const sentinelFile = join(root, 'descendant-survived');
 		const startedFile = join(root, 'descendant-started');
+		const argumentsFile = join(root, 'arguments.json');
+		const forwarded = ['spaced argument', 'café', '%literal%', 'a&b'];
 		const controlFile = join(root, 'command.json');
 		await mkdir(toolRoot);
 		await writeFile(
@@ -449,8 +414,10 @@ test.skipIf(process.platform !== 'win32')(
 			[
 				"import { spawn } from 'node:child_process';",
 				"import { existsSync } from 'node:fs';",
+				"import { writeFile } from 'node:fs/promises';",
 				"import { setTimeout as delay } from 'node:timers/promises';",
-				'const [startedFile, sentinelFile] = process.argv.slice(2);',
+				'const [argumentsFile, startedFile, sentinelFile, ...forwarded] = process.argv.slice(2);',
+				'await writeFile(argumentsFile, JSON.stringify(forwarded));',
 				`const descendant = spawn(process.execPath, [${JSON.stringify(descendantScript)}, startedFile, sentinelFile], {`,
 				"\tstdio: 'ignore',",
 				'});',
@@ -469,7 +436,7 @@ test.skipIf(process.platform !== 'win32')(
 			controlFile,
 			JSON.stringify({
 				file: batchFile,
-				args: [startedFile, sentinelFile],
+				args: [argumentsFile, startedFile, sentinelFile, ...forwarded],
 			})
 		);
 		const [file, ...args] = windowsJobSupervisorCommand(controlFile);
@@ -527,6 +494,7 @@ test.skipIf(process.platform !== 'win32')(
 				);
 			});
 			await expect(readFile(startedFile, 'utf8')).resolves.toBe('started');
+			await expect(readFile(argumentsFile, 'utf8').then(JSON.parse)).resolves.toEqual(forwarded);
 			const closed = once(runningSupervisor, 'close');
 			expect(runningSupervisor.kill()).toBe(true);
 			await closed;
@@ -828,6 +796,17 @@ describe('isolatedBootstrapEnvironment', () => {
 			})
 		).toEqual({
 			NODE_OPTIONS: '--max-old-space-size=4096 --conditions="development test" --trace-warnings',
+		});
+	});
+
+	test('removes fully quoted loader options while preserving fully quoted non-loaders', () => {
+		expect(
+			isolatedBootstrapEnvironment({
+				NODE_OPTIONS:
+					'"--require=C:\\project\\double.cjs" \'--import=./single.mjs\' "--loader" "./double-loader.mjs" \'--experimental-loader\' \'./single-loader.mjs\' "--max-old-space-size=4096" \'--conditions=development\'',
+			})
+		).toEqual({
+			NODE_OPTIONS: '"--max-old-space-size=4096" \'--conditions=development\'',
 		});
 	});
 });

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -177,6 +177,31 @@ describe('terminateChildProcess', () => {
 		}
 	);
 
+	test.skipIf(process.platform === 'win32')(
+		'terminates a detached process group after its leader exits',
+		async () => {
+			const child = spawnChild('sh', ['-c', 'sleep 30 & exit 0'], {
+				detached: true,
+				stdio: 'ignore',
+			});
+			await once(child, 'spawn');
+			const pid = child.pid!;
+
+			try {
+				await once(child, 'close');
+				await terminateChildProcess(child, process.platform, 500);
+
+				expect(() => process.kill(-pid, 0)).toThrow(/ESRCH/);
+			} finally {
+				try {
+					process.kill(-pid, 'SIGKILL');
+				} catch {
+					// The process group was already terminated.
+				}
+			}
+		}
+	);
+
 	test('shares Windows taskkill across concurrent and late stop requests', async () => {
 		const root = await temporaryRoot();
 		const bin = join(root, 'bin');

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -2,7 +2,9 @@ import { type ChildProcess, spawn as spawnChild } from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
 import { createRequire } from 'node:module';
 import {
+	appendFile,
 	mkdir,
+	lstat,
 	mkdtemp,
 	readFile,
 	readlink,
@@ -12,7 +14,7 @@ import {
 	writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { setTimeout as delay } from 'node:timers/promises';
 import { afterEach, describe, expect, test, vi } from 'vitest';
@@ -24,7 +26,6 @@ import {
 	createRuntimeDependencies,
 	determineBisectProgress,
 	developmentServerStdio,
-	dependencySymlinkType,
 	detectPackageManager,
 	detectPackageManagerRoot,
 	discoverAstroWorkspacePackages,
@@ -38,6 +39,7 @@ import {
 	RuntimeSession,
 	resolveInstalledPackageManifest,
 	restoreDependencySymlink,
+	snapshotDependencySymlinks,
 	selectLatestAstroReleaseTag,
 	selectLatestAstroReleaseRevision,
 	selectLatestAstroRevision,
@@ -244,6 +246,121 @@ test('aborts a PnP reader launched after setup starts without caching its manife
 	} finally {
 		await terminateChildProcess(reader);
 	}
+});
+
+test('evicts a failed in-flight PnP manifest read before a successful retry', async () => {
+	const project = await createPnpArchiveProject();
+	let launches = 0;
+	const failedLaunch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		launches += 1;
+		const reader = Object.assign(new EventEmitter(), {
+			stdout: new PassThrough(),
+			stderr: new PassThrough(),
+		}) as unknown as ChildProcess;
+		observe?.(reader);
+		process.nextTick(() => {
+			reader.emit('exit', 1);
+			reader.emit('close', 1);
+		});
+		return reader;
+	};
+	const successfulLaunch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		launches += 1;
+		const stdout = new PassThrough();
+		const reader = Object.assign(new EventEmitter(), {
+			stdout,
+			stderr: new PassThrough(),
+		}) as unknown as ChildProcess;
+		observe?.(reader);
+		process.nextTick(() => {
+			stdout.write(JSON.stringify({ name: 'astro', version: '7.0.0' }));
+			reader.emit('exit', 0);
+			reader.emit('close', 0);
+		});
+		return reader;
+	};
+
+	await expect(
+		resolveInstalledPackageManifest('astro', project, undefined, undefined, failedLaunch)
+	).rejects.toThrow('exit code 1');
+	await expect(
+		resolveInstalledPackageManifest('astro', project, undefined, undefined, successfulLaunch)
+	).resolves.toMatch(/astro\.zip[\\/]node_modules[\\/]astro[\\/]package\.json$/);
+	expect(launches).toBe(2);
+});
+
+test('evicts an aborted in-flight PnP manifest read before a successful retry', async () => {
+	const project = await createPnpArchiveProject();
+	const controller = new AbortController();
+	const launched = Promise.withResolvers<void>();
+	let launches = 0;
+	const hangingLaunch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		launches += 1;
+		const reader = Object.assign(new EventEmitter(), {
+			stdout: new PassThrough(),
+			stderr: new PassThrough(),
+		}) as unknown as ChildProcess;
+		observe?.(reader);
+		launched.resolve();
+		return reader;
+	};
+	const successfulLaunch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		launches += 1;
+		const stdout = new PassThrough();
+		const reader = Object.assign(new EventEmitter(), {
+			stdout,
+			stderr: new PassThrough(),
+		}) as unknown as ChildProcess;
+		observe?.(reader);
+		process.nextTick(() => {
+			stdout.write(JSON.stringify({ name: 'astro', version: '7.0.0' }));
+			reader.emit('exit', 0);
+			reader.emit('close', 0);
+		});
+		return reader;
+	};
+	const pending = resolveInstalledPackageManifest(
+		'astro',
+		project,
+		undefined,
+		controller.signal,
+		hangingLaunch,
+		async (reader) => {
+			reader?.emit('close', null);
+		}
+	);
+	await launched.promise;
+	controller.abort('cancelled reader');
+
+	await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+	await expect(
+		resolveInstalledPackageManifest('astro', project, undefined, undefined, successfulLaunch)
+	).resolves.toMatch(/astro\.zip[\\/]node_modules[\\/]astro[\\/]package\.json$/);
+	expect(launches).toBe(2);
 });
 
 test.skipIf(process.platform === 'win32')(
@@ -563,7 +680,11 @@ describe('terminateChildProcess', () => {
 	);
 
 	test('shares Windows taskkill across concurrent and late stop requests', async () => {
-		const child = { pid: 4_242, exitCode: null, signalCode: null } as ChildProcess;
+		const child = Object.assign(new EventEmitter(), {
+			pid: 4_242,
+			exitCode: null,
+			signalCode: null,
+		}) as ChildProcess;
 		const taskkill = new EventEmitter();
 		const launchTaskkill = vi.fn<(pid: number) => ChildProcess>(() => taskkill as ChildProcess);
 		const first = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
@@ -572,6 +693,7 @@ describe('terminateChildProcess', () => {
 		expect(second).toBe(first);
 		expect(launchTaskkill).toHaveBeenCalledExactlyOnceWith(4_242);
 		taskkill.emit('close', 0);
+		child.emit('close', 0);
 		await Promise.all([first, second]);
 		await terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
 
@@ -606,6 +728,7 @@ describe('terminateChildProcess', () => {
 			setTimeout(() => {
 				testChild.exitCode = 0;
 				testChild.emit('exit', 0);
+				testChild.emit('close', 0);
 			}, 1);
 			await vi.advanceTimersByTimeAsync(1);
 
@@ -617,6 +740,34 @@ describe('terminateChildProcess', () => {
 			vi.useRealTimers();
 		}
 	});
+	test.skipIf(process.platform !== 'win32')(
+		'does not finish a successful Windows stop until the supervisor closes',
+		async () => {
+			const child = Object.assign(new EventEmitter(), {
+				pid: 4_242,
+				exitCode: null,
+				signalCode: null,
+			}) as ChildProcess;
+			const taskkill = new EventEmitter();
+			const termination = terminateChildProcess(
+				child,
+				'win32',
+				5_000,
+				() => taskkill as ChildProcess
+			);
+			let finished = false;
+			void termination.then(() => {
+				finished = true;
+			});
+
+			taskkill.emit('close', 0);
+			await Promise.resolve();
+			expect(finished).toBe(false);
+			child.emit('close', 0);
+
+			await expect(termination).resolves.toBeUndefined();
+		}
+	);
 
 	test('reports a Windows taskkill failure while the child is still running', async () => {
 		vi.useFakeTimers();
@@ -665,6 +816,7 @@ describe('terminateChildProcess', () => {
 			);
 			const second = terminateChildProcess(child, 'win32', 5_000, launchTaskkill);
 			secondTaskkill.emit('close', 0);
+			child.emit('close', 0);
 
 			await expect(second).resolves.toBeUndefined();
 			expect(launchTaskkill).toHaveBeenCalledTimes(2);
@@ -713,6 +865,50 @@ describe('terminateChildProcess', () => {
 		await expect(execution).rejects.toBe(terminationError);
 		await expect(session.close()).rejects.toThrow('every-astro cleanup failed');
 		expect(terminate).toHaveBeenCalledTimes(2);
+	});
+	test('keeps a development-server early-exit error ahead of its stop failure', async () => {
+		const project = await createProject();
+		const temporary = await temporaryRoot();
+		const child = new EventEmitter() as ChildProcess;
+		const stopError = new Error('could not stop development server');
+		const terminate = vi.fn(async () => {
+			throw stopError;
+		});
+		const session = new RuntimeSession(
+			project,
+			project,
+			join(temporary, 'astro'),
+			temporary,
+			'',
+			'npm',
+			false,
+			{ exists: true, content: Buffer.from('{}\n') },
+			{ exists: true, content: Buffer.from('{}\n') },
+			join(project, 'package-lock.json'),
+			{ exists: true, content: Buffer.from('{}\n') },
+			[],
+			new Set(),
+			'',
+			new AbortController().signal,
+			terminate,
+			() => {
+				process.nextTick(() => child.emit('exit', 1));
+				return child;
+			}
+		);
+
+		let failure: unknown;
+		try {
+			await session.runDevServerAndAsk('revision');
+		} catch (error) {
+			failure = error;
+		}
+
+		expect(failure).toBeInstanceOf(AggregateError);
+		const aggregate = failure as AggregateError;
+		expect(aggregate.cause).toBe(aggregate.errors[0]);
+		expect(aggregate.errors[0]).toMatchObject({ name: 'CommandError' });
+		expect(aggregate.errors[1]).toBe(stopError);
 	});
 });
 
@@ -1130,9 +1326,51 @@ describe('restoreDependencySymlink', () => {
 		await expect(installedAstroMajor(project)).resolves.toBe(7);
 	});
 
-	test('uses junctions for Windows directory links', () => {
-		expect(dependencySymlinkType('win32')).toBe('junction');
-	});
+	test.skipIf(process.platform !== 'win32')(
+		'preserves relative symbolic links and junctions through the dependency snapshot and restore cycle',
+		async () => {
+			const project = await createProject();
+			const symbolicTarget = join(project, 'packages', 'symbolic-target');
+			const junctionTarget = join(project, 'packages', 'junction-target');
+			const symbolicLink = join(project, 'node_modules', 'astro');
+			const junctionLink = join(project, 'node_modules', '@astrojs', 'junction');
+			await Promise.all([
+				mkdir(symbolicTarget, { recursive: true }),
+				mkdir(junctionTarget, { recursive: true }),
+				mkdir(dirname(symbolicLink), { recursive: true }),
+				mkdir(dirname(junctionLink), { recursive: true }),
+			]);
+			const relativeTarget = join('..', 'packages', 'symbolic-target');
+			await symlink(relativeTarget, symbolicLink, 'dir');
+			await symlink(junctionTarget, junctionLink, 'junction');
+
+			const snapshots = await snapshotDependencySymlinks(
+				project,
+				project,
+				new Set(['astro', '@astrojs/junction'])
+			);
+			const byPath = new Map(snapshots.map((snapshot) => [snapshot.path, snapshot]));
+			expect(byPath.get(symbolicLink)).toMatchObject({
+				target: relativeTarget,
+				type: 'dir',
+			});
+			expect(byPath.get(junctionLink)).toMatchObject({ type: 'junction' });
+
+			await rm(symbolicLink, { recursive: true, force: true });
+			await rm(junctionLink, { recursive: true, force: true });
+			await Promise.all(snapshots.map((snapshot) => restoreDependencySymlink(snapshot)));
+
+			expect((await lstat(symbolicLink)).isSymbolicLink()).toBe(true);
+			await expect(readlink(symbolicLink)).resolves.toBe(relativeTarget);
+			const restored = await snapshotDependencySymlinks(
+				project,
+				project,
+				new Set(['@astrojs/junction'])
+			);
+			expect(restored).toHaveLength(1);
+			expect(restored[0]).toMatchObject({ path: junctionLink, type: 'junction' });
+		}
+	);
 });
 
 describe('isolatedBootstrapEnvironment', () => {
@@ -1281,6 +1519,39 @@ describe('createRuntimeDependencies', () => {
 		await expect(dependencies.createSession()).rejects.toThrow(
 			'every-astro requires a npm lockfile to restore the exact dependency tree'
 		);
+	});
+
+	test('coalesces concurrent Corepack PnP reads of the same archive manifest', async () => {
+		const project = await createProject({
+			packageManager: 'yarn@4.17.1',
+			dependencies: { astro: '7.0.0' },
+		});
+		const packageRoot = join(project, '.yarn/cache/astro.zip/node_modules/astro');
+		const launches = join(project, 'pnp-reader-launches');
+		await mkdir(join(project, '.yarn/cache'), { recursive: true });
+		await mkdir(join(project, '.yarn/releases'), { recursive: true });
+		await writeFile(join(project, '.yarn/cache/astro.zip'), '');
+		await writeFile(
+			join(project, '.pnp.cjs'),
+			`exports.resolveToUnqualified = (request) => request === 'astro' ? ${JSON.stringify(packageRoot)} : null;\n`
+		);
+		await writeFile(
+			join(project, '.yarnrc.yml'),
+			'yarnPath: .yarn/releases/reader.cjs\nnodeLinker: pnp\n'
+		);
+		await writeFile(
+			join(project, '.yarn/releases/reader.cjs'),
+			[
+				"const { appendFileSync } = require('node:fs');",
+				`appendFileSync(${JSON.stringify(launches)}, 'reader\\n');`,
+				"process.stdout.write(JSON.stringify({ name: 'astro', version: '7.0.0' }));",
+			].join('\n')
+		);
+
+		await expect(
+			createRuntimeDependencies(project, new AbortController().signal)
+		).resolves.toBeDefined();
+		await expect(readFile(launches, 'utf8')).resolves.toBe('reader\n');
 	});
 
 	test('aborts and reaps the Corepack Yarn PnP manifest reader process tree', async () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -1472,6 +1472,18 @@ describe('packed workspace package activation', () => {
 	);
 });
 
+describe('snapshotDependencySymlinks', () => {
+	test('honors cancellation before scanning dependency links', async () => {
+		const project = await createProject();
+		const controller = new AbortController();
+		controller.abort('stop dependency scan');
+
+		await expect(
+			snapshotDependencySymlinks(project, project, new Set(['astro']), controller.signal)
+		).rejects.toMatchObject({ name: 'AbortError' });
+	});
+});
+
 describe('restoreDependencySymlink', () => {
 	test('restores the saved directory link target', async () => {
 		const project = await createProject({ dependencies: { astro: '7.0.0' } });

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -390,10 +390,9 @@ test('rejects a newly aborted caller even after its PnP manifest was cached', as
 	).resolves.toMatch(/astro\.zip[\\/]node_modules[\\/]astro[\\/]package\.json$/);
 
 	const controller = new AbortController();
+	const cached = resolveInstalledPackageManifest('astro', project, undefined, controller.signal);
 	controller.abort('cached caller cancelled');
-	await expect(
-		resolveInstalledPackageManifest('astro', project, undefined, controller.signal)
-	).rejects.toMatchObject({ name: 'AbortError' });
+	await expect(cached).rejects.toMatchObject({ name: 'AbortError' });
 });
 
 test('does not attach an aborting handoff caller to a draining PnP generation', async () => {
@@ -988,6 +987,54 @@ describe('terminateChildProcess', () => {
 		await expect(execution).rejects.toBe(terminationError);
 		await expect(session.close()).rejects.toThrow('every-astro cleanup failed');
 		expect(terminate).toHaveBeenCalledTimes(2);
+	});
+
+	test('bootstrap teardown retries its active clone without restoring consumer dependencies', async () => {
+		const project = await createProject();
+		const temporary = await temporaryRoot();
+		const sentinel = join(project, 'node_modules', 'sentinel');
+		await mkdir(dirname(sentinel), { recursive: true });
+		await writeFile(sentinel, 'unchanged');
+		const controller = new AbortController();
+		const child = new EventEmitter() as ChildProcess;
+		const terminationError = new Error('initial clone stop failed');
+		const terminate = vi
+			.fn<(child: ChildProcess | undefined) => Promise<void>>()
+			.mockRejectedValueOnce(terminationError)
+			.mockResolvedValueOnce(undefined);
+		const commandSpawner = vi.fn(() => child);
+		const session = new RuntimeSession(
+			project,
+			project,
+			join(temporary, 'astro'),
+			temporary,
+			'',
+			'npm',
+			false,
+			{ exists: true, content: Buffer.from('{}\n') },
+			{ exists: true, content: Buffer.from('{}\n') },
+			join(project, 'package-lock.json'),
+			{ exists: true, content: Buffer.from('{}\n') },
+			[],
+			new Set(),
+			'',
+			controller.signal,
+			terminate,
+			commandSpawner
+		);
+		const clone = session.execute(['git', 'clone', 'fixture'], temporary);
+		controller.abort();
+
+		await expect(clone).rejects.toBe(terminationError);
+		await expect(session.closeBootstrap()).resolves.toBeUndefined();
+		expect(terminate).toHaveBeenCalledTimes(2);
+		expect(commandSpawner).toHaveBeenCalledExactlyOnceWith('git', ['clone', 'fixture'], {
+			cwd: temporary,
+			detached: process.platform !== 'win32',
+			env: undefined,
+			stdio: 'inherit',
+		});
+		await expect(readFile(sentinel, 'utf8')).resolves.toBe('unchanged');
 	});
 	test('keeps a development-server early-exit error ahead of its stop failure', async () => {
 		const project = await createProject();

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -8,6 +8,8 @@ import {
 	detectPackageManager,
 	discoverAstroWorkspacePackages,
 	installedAstroMajor,
+	isolatedBootstrapEnvironment,
+	linkBunPackage,
 	packageLinkCommands,
 	resolveInstalledPackageManifest,
 } from '../src/runtime.js';
@@ -80,19 +82,31 @@ describe('detectPackageManager', () => {
 });
 
 describe('packageLinkCommands', () => {
-	test('uses local folder dependencies for Bun without touching its global link registry', () => {
+	test('does not invoke Bun when packages are linked directly into node_modules', () => {
 		const project = '/project';
 		const links = [
 			{ name: 'astro', path: '/checkout/packages/astro' },
 			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler' },
 		];
 
-		expect(packageLinkCommands('bun', false, project, links)).toEqual([
-			{
-				command: ['bun', 'add', '--no-save', ...links.map(({ path }) => path)],
-				cwd: project,
-			},
-		]);
+		expect(packageLinkCommands('bun', false, project, links)).toEqual([]);
+	});
+
+	test('replaces Bun-installed packages with the checked-out revision', async () => {
+		const project = await createProject({ dependencies: { astro: '7.0.0' } });
+		const revision = await temporaryRoot();
+		await writePackage(project, 'node_modules/astro', {
+			name: 'astro',
+			version: '7.0.0',
+		});
+		await writeJson(join(revision, 'package.json'), {
+			name: 'astro',
+			version: '0.0.0-revision',
+		});
+
+		await linkBunPackage(project, { name: 'astro', path: revision });
+
+		await expect(installedAstroMajor(project)).resolves.toBe(0);
 	});
 
 	test('uses the Classic Yarn link protocol entirely from the target project', () => {
@@ -114,6 +128,37 @@ describe('packageLinkCommands', () => {
 				cwd: project,
 			},
 		]);
+	});
+
+	test('uses portal dependencies for Yarn Berry packages in pnpm workspaces', () => {
+		const project = '/project';
+		const links = [
+			{ name: 'astro', path: '/checkout/packages/astro' },
+			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler' },
+		];
+
+		expect(packageLinkCommands('yarn', true, project, links)).toEqual([
+			{
+				command: [
+					'yarn',
+					'add',
+					'astro@portal:/checkout/packages/astro',
+					'@astrojs/compiler@portal:/checkout/packages/compiler',
+				],
+				cwd: project,
+			},
+		]);
+	});
+});
+
+describe('isolatedBootstrapEnvironment', () => {
+	test('removes consumer Node loader hooks without changing other environment values', () => {
+		expect(
+			isolatedBootstrapEnvironment({
+				NODE_OPTIONS: '--require /project/.pnp.cjs',
+				COREPACK_HOME: '/cache/corepack',
+			})
+		).toEqual({ COREPACK_HOME: '/cache/corepack' });
 	});
 });
 

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -191,7 +191,7 @@ describe('terminateChildProcess', () => {
 		process.env.PATH = `${bin}:${originalPath ?? ''}`;
 		process.env.TASKKILL_LOG = log;
 		try {
-			const child = { pid: process.pid } as ChildProcess;
+			const child = { pid: process.pid, exitCode: null, signalCode: null } as ChildProcess;
 			const first = terminateChildProcess(child, 'win32');
 			const second = terminateChildProcess(child, 'win32');
 
@@ -205,6 +205,89 @@ describe('terminateChildProcess', () => {
 			else process.env.PATH = originalPath;
 			if (originalLog === undefined) delete process.env.TASKKILL_LOG;
 			else process.env.TASKKILL_LOG = originalLog;
+		}
+	});
+
+	test('does not taskkill a Windows child that exited naturally', async () => {
+		const root = await temporaryRoot();
+		const bin = join(root, 'bin');
+		const log = join(root, 'taskkill.log');
+		const taskkill = join(bin, 'taskkill');
+		await mkdir(bin);
+		await writeFile(taskkill, '#!/bin/sh\nprintf "%s\\n" "$@" >> "$TASKKILL_LOG"\n');
+		await chmod(taskkill, 0o755);
+
+		const originalPath = process.env.PATH;
+		const originalLog = process.env.TASKKILL_LOG;
+		process.env.PATH = `${bin}:${originalPath ?? ''}`;
+		process.env.TASKKILL_LOG = log;
+		try {
+			const child = { pid: process.pid, exitCode: 0, signalCode: null } as ChildProcess;
+			const first = terminateChildProcess(child, 'win32');
+			const late = terminateChildProcess(child, 'win32');
+
+			expect(late).toBe(first);
+			await first;
+			await expect(readFile(log, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			if (originalLog === undefined) delete process.env.TASKKILL_LOG;
+			else process.env.TASKKILL_LOG = originalLog;
+		}
+	});
+
+	test('accepts a Windows taskkill race after the child exits', async () => {
+		const root = await temporaryRoot();
+		const bin = join(root, 'bin');
+		const log = join(root, 'taskkill.log');
+		const taskkill = join(bin, 'taskkill');
+		await mkdir(bin);
+		await writeFile(
+			taskkill,
+			'#!/bin/sh\nprintf "%s\\n" "$@" >> "$TASKKILL_LOG"\nsleep 0.05\nexit 1\n'
+		);
+		await chmod(taskkill, 0o755);
+
+		const originalPath = process.env.PATH;
+		const originalLog = process.env.TASKKILL_LOG;
+		process.env.PATH = `${bin}:${originalPath ?? ''}`;
+		process.env.TASKKILL_LOG = log;
+		try {
+			const testChild = { pid: process.pid, exitCode: null as number | null, signalCode: null };
+			const child = testChild as ChildProcess;
+			const termination = terminateChildProcess(child, 'win32');
+			testChild.exitCode = 0;
+
+			await expect(termination).resolves.toBeUndefined();
+			expect((await readFile(log, 'utf8')).match(/^\/pid$/gm) ?? []).toHaveLength(1);
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			if (originalLog === undefined) delete process.env.TASKKILL_LOG;
+			else process.env.TASKKILL_LOG = originalLog;
+		}
+	});
+
+	test('reports a Windows taskkill failure while the child is still running', async () => {
+		const root = await temporaryRoot();
+		const bin = join(root, 'bin');
+		const taskkill = join(bin, 'taskkill');
+		await mkdir(bin);
+		await writeFile(taskkill, '#!/bin/sh\nexit 1\n');
+		await chmod(taskkill, 0o755);
+
+		const originalPath = process.env.PATH;
+		process.env.PATH = `${bin}:${originalPath ?? ''}`;
+		try {
+			const child = { pid: process.pid, exitCode: null, signalCode: null } as ChildProcess;
+
+			await expect(terminateChildProcess(child, 'win32')).rejects.toThrow(
+				`taskkill failed while terminating process ${process.pid} (exit code 1)`
+			);
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
 		}
 	});
 });
@@ -282,6 +365,26 @@ describe('packageLinkCommands', () => {
 		await linkBunPackage(project, { name: 'astro', path: revision });
 
 		await expect(installedAstroMajor(project)).resolves.toBe(0);
+	});
+
+	test('links new scoped workspace dependencies absent from the original Bun installation', async () => {
+		const project = await createProject({ dependencies: { astro: '7.0.0' } });
+		const revision = await temporaryRoot();
+		await writePackage(project, 'node_modules/astro', {
+			name: 'astro',
+			version: '7.0.0',
+		});
+		await writeJson(join(revision, 'package.json'), {
+			name: '@astrojs/new-helper',
+			version: '0.0.0-revision',
+		});
+
+		await expect(
+			linkBunPackage(project, { name: '@astrojs/new-helper', path: revision })
+		).resolves.toBe(join(project, 'node_modules', '@astrojs/new-helper'));
+		await expect(readlink(join(project, 'node_modules', '@astrojs/new-helper'))).resolves.toBe(
+			revision
+		);
 	});
 
 	test('uses publish-shaped file descriptors for Classic Yarn packages', () => {
@@ -461,7 +564,9 @@ describe('createRuntimeDependencies', () => {
 			dependencies: { astro: '^7.0.0' },
 		});
 		await writePackage(project, 'node_modules/astro', { name: 'astro', version: '7.0.0' });
-		const dependencies = await createRuntimeDependencies(project, new AbortController().signal);
+		const controller = new AbortController();
+		const dependencies = await createRuntimeDependencies(project, controller.signal);
+		expect(dependencies.signal).toBe(controller.signal);
 
 		await expect(dependencies.createSession()).rejects.toThrow(
 			'every-astro requires a npm lockfile to restore the exact dependency tree'

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn as spawnChild } from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
+import { createRequire } from 'node:module';
 import {
 	mkdir,
 	mkdtemp,
@@ -44,6 +45,8 @@ import {
 const temporaryRoots: string[] = [];
 type PackageManager = 'pnpm' | 'yarn' | 'bun' | 'npm';
 
+const spawnCross = createRequire(import.meta.url)('cross-spawn') as typeof spawnChild;
+
 async function temporaryRoot(): Promise<string> {
 	const root = await mkdtemp(join(tmpdir(), 'every-astro-test-'));
 	temporaryRoots.push(root);
@@ -75,7 +78,7 @@ async function runCommand(
 	cwd: string,
 	environment: NodeJS.ProcessEnv = {}
 ): Promise<string> {
-	const child = spawnChild(command, args, {
+	const child = spawnCross(command, args, {
 		cwd,
 		env: { ...process.env, ...environment },
 		stdio: ['ignore', 'pipe', 'pipe'],
@@ -312,7 +315,8 @@ describe('terminateChildProcess', () => {
 			new Set(),
 			'',
 			controller.signal,
-			terminate
+			terminate,
+			() => new EventEmitter() as ChildProcess
 		);
 		const controllableSession = session as unknown as {
 			unlinkPackages(): Promise<void>;
@@ -321,7 +325,7 @@ describe('terminateChildProcess', () => {
 		vi.spyOn(controllableSession, 'unlinkPackages').mockResolvedValue();
 		vi.spyOn(controllableSession, 'restoreDependencies').mockResolvedValue();
 
-		const execution = session.execute([process.execPath, '-e', ''], project);
+		const execution = session.execute(['fixture-command'], project);
 		controller.abort();
 
 		await expect(execution).rejects.toBe(terminationError);

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -13,6 +13,7 @@ import {
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
 	abortError,
@@ -384,19 +385,29 @@ describe('windowsJobSupervisorCommand', () => {
 });
 
 test.skipIf(process.platform !== 'win32')(
-	'launches a target through the Job Object supervisor and removes its control file',
+	'forwards Unicode arguments through a Unicode batch target and removes its control file',
 	async () => {
 		const root = await temporaryRoot();
 		const toolRoot = join(root, 'tool path café');
 		const batchFile = join(toolRoot, 'runner.cmd');
+		const targetScript = join(toolRoot, 'target.mjs');
+		const argumentsFile = join(root, 'arguments.json');
 		const controlFile = join(root, 'command.json');
+		const forwarded = ['spaced argument', 'café', '%literal%', 'a&b'];
 		await mkdir(toolRoot);
-		await writeFile(batchFile, '@echo off\r\nexit /b 0\r\n');
+		await writeFile(
+			targetScript,
+			[
+				"import { writeFile } from 'node:fs/promises';",
+				'await writeFile(process.argv[2], JSON.stringify(process.argv.slice(3)));',
+			].join('\n')
+		);
+		await writeFile(batchFile, `@echo off\r\n"${process.execPath}" "${targetScript}" %*\r\n`);
 		await writeFile(
 			controlFile,
 			JSON.stringify({
 				file: batchFile,
-				args: ['spaced argument', 'café', '%literal%', 'a&b'],
+				args: [argumentsFile, ...forwarded],
 			})
 		);
 		const [file, ...args] = windowsJobSupervisorCommand(controlFile);
@@ -405,7 +416,74 @@ test.skipIf(process.platform !== 'win32')(
 		const [exitCode] = (await once(child, 'close')) as [number | null];
 
 		expect(exitCode).toBe(0);
+		await expect(readFile(argumentsFile, 'utf8').then(JSON.parse)).resolves.toEqual(forwarded);
 		await expect(readFile(controlFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+	}
+);
+
+test.skipIf(process.platform !== 'win32')(
+	'kills a delayed descendant when the supervisor closes its Job Object',
+	async () => {
+		const root = await temporaryRoot();
+		const toolRoot = join(root, 'job café');
+		const batchFile = join(toolRoot, 'runner.cmd');
+		const targetScript = join(toolRoot, 'target.mjs');
+		const descendantScript = join(toolRoot, 'descendant.mjs');
+		const sentinelFile = join(root, 'descendant-survived');
+		const controlFile = join(root, 'command.json');
+		await mkdir(toolRoot);
+		await writeFile(
+			descendantScript,
+			[
+				"import { writeFile } from 'node:fs/promises';",
+				"import { setTimeout as delay } from 'node:timers/promises';",
+				'await delay(250);',
+				"await writeFile(process.argv[2], 'escaped');",
+			].join('\n')
+		);
+		await writeFile(
+			targetScript,
+			[
+				"import { spawn } from 'node:child_process';",
+				"import { setTimeout as delay } from 'node:timers/promises';",
+				`const descendant = spawn(process.execPath, [${JSON.stringify(descendantScript)}, process.argv[2]], {`,
+				"\tstdio: 'ignore',",
+				'});',
+				'descendant.unref();',
+				"console.log('ready');",
+				'await delay(600);',
+			].join('\n')
+		);
+		await writeFile(batchFile, `@echo off\r\n"${process.execPath}" "${targetScript}" %*\r\n`);
+		await writeFile(
+			controlFile,
+			JSON.stringify({
+				file: batchFile,
+				args: [sentinelFile],
+			})
+		);
+		const [file, ...args] = windowsJobSupervisorCommand(controlFile);
+		let supervisor: ChildProcess | undefined;
+		try {
+			supervisor = spawnChild(file, args, {
+				cwd: root,
+				stdio: ['ignore', 'pipe', 'pipe'],
+			});
+			await once(supervisor.stdout!, 'data');
+			const closed = once(supervisor, 'close');
+			expect(supervisor.kill()).toBe(true);
+			await closed;
+
+			// The external descendant uses the Windows scheduler, which Vitest fake timers cannot drive.
+			await delay(750);
+			await expect(readFile(sentinelFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+		} finally {
+			if (supervisor?.exitCode === null && supervisor.signalCode === null) {
+				const closed = once(supervisor, 'close');
+				supervisor.kill();
+				await closed;
+			}
+		}
 	}
 );
 

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -363,6 +363,129 @@ test('evicts an aborted in-flight PnP manifest read before a successful retry', 
 	expect(launches).toBe(2);
 });
 
+test('rejects a newly aborted caller even after its PnP manifest was cached', async () => {
+	const project = await createPnpArchiveProject();
+	const stdout = new PassThrough();
+	const reader = Object.assign(new EventEmitter(), {
+		stdout,
+		stderr: new PassThrough(),
+	}) as unknown as ChildProcess;
+	const launch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		observe?.(reader);
+		process.nextTick(() => {
+			stdout.write(JSON.stringify({ name: 'astro', version: '7.0.0' }));
+			reader.emit('exit', 0);
+			reader.emit('close', 0);
+		});
+		return reader;
+	};
+	await expect(
+		resolveInstalledPackageManifest('astro', project, undefined, undefined, launch)
+	).resolves.toMatch(/astro\.zip[\\/]node_modules[\\/]astro[\\/]package\.json$/);
+
+	const controller = new AbortController();
+	controller.abort('cached caller cancelled');
+	await expect(
+		resolveInstalledPackageManifest('astro', project, undefined, controller.signal)
+	).rejects.toMatchObject({ name: 'AbortError' });
+});
+
+test('does not attach an aborting handoff caller to a draining PnP generation', async () => {
+	const project = await createPnpArchiveProject();
+	const firstLaunched = Promise.withResolvers<void>();
+	const cleanupStarted = Promise.withResolvers<void>();
+	const cleanupRelease = Promise.withResolvers<void>();
+	let launches = 0;
+	let terminating = false;
+	const launch = async (
+		_temporaryRoot: string,
+		_file: string,
+		_args: string[],
+		_options: NonNullable<Parameters<typeof spawnCross>[2]>,
+		observe?: (child: ChildProcess) => void
+	): Promise<ChildProcess> => {
+		launches += 1;
+		const stdout = new PassThrough();
+		const reader = Object.assign(new EventEmitter(), {
+			stdout,
+			stderr: new PassThrough(),
+		}) as unknown as ChildProcess;
+		observe?.(reader);
+		if (launches === 1) {
+			firstLaunched.resolve();
+		} else {
+			process.nextTick(() => {
+				stdout.write(JSON.stringify({ name: 'astro', version: '7.0.0' }));
+				reader.emit('exit', 0);
+				reader.emit('close', 0);
+			});
+		}
+		return reader;
+	};
+	const terminate = async (reader: ChildProcess | undefined): Promise<void> => {
+		if (terminating) return;
+		terminating = true;
+		cleanupStarted.resolve();
+		await cleanupRelease.promise;
+		reader?.emit('close', null);
+	};
+	const firstController = new AbortController();
+	const secondController = new AbortController();
+	const first = resolveInstalledPackageManifest(
+		'astro',
+		project,
+		undefined,
+		firstController.signal,
+		launch,
+		terminate
+	);
+	void first.catch(() => undefined);
+	const second = resolveInstalledPackageManifest(
+		'astro',
+		project,
+		undefined,
+		secondController.signal,
+		launch,
+		terminate
+	);
+	await firstLaunched.promise;
+	void second.catch(() => undefined);
+	firstController.abort('first caller cancelled');
+	secondController.abort('second caller cancelled');
+	await cleanupStarted.promise;
+
+	const liveController = new AbortController();
+	const live = resolveInstalledPackageManifest(
+		'astro',
+		project,
+		undefined,
+		liveController.signal,
+		launch,
+		terminate
+	);
+	void live.catch(() => undefined);
+	await Promise.resolve();
+	expect(launches).toBe(1);
+	const liveResult = expect(live).rejects.toMatchObject({ name: 'AbortError' });
+	liveController.abort('handoff caller cancelled');
+
+	await liveResult;
+	expect(launches).toBe(1);
+	cleanupRelease.resolve();
+	await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+	await expect(second).rejects.toMatchObject({ name: 'AbortError' });
+	await expect(
+		resolveInstalledPackageManifest('astro', project, undefined, undefined, launch, terminate)
+	).resolves.toMatch(/astro\.zip[\\/]node_modules[\\/]astro[\\/]package\.json$/);
+	expect(launches).toBe(2);
+});
+
 test.skipIf(process.platform === 'win32')(
 	'aborts while successful PnP reader descendant cleanup is pending without caching',
 	async () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -172,6 +172,57 @@ test.each([
 	}
 });
 
+test('aborts a PnP reader launched after setup starts without caching its manifest', async () => {
+	const project = await createProject({
+		packageManager: 'yarn@4.17.1',
+		dependencies: { astro: '7.0.0' },
+	});
+	const packageRoot = join(project, '.yarn/cache/astro.zip/node_modules/astro');
+	await mkdir(join(project, '.yarn/cache'), { recursive: true });
+	await writeFile(join(project, '.yarn/cache/astro.zip'), '');
+	await writeFile(
+		join(project, '.pnp.cjs'),
+		`exports.resolveToUnqualified = (request) => request === 'astro' ? ${JSON.stringify(packageRoot)} : null;\n`
+	);
+	await writeFile(
+		join(project, '.yarnrc.yml'),
+		'yarnPath: .yarn/releases/reader.cjs\nnodeLinker: pnp\n'
+	);
+	await mkdir(join(project, '.yarn/releases'), { recursive: true });
+	// The reader stays alive until setup-window abort handling terminates it.
+	await writeFile(join(project, '.yarn/releases/reader.cjs'), 'setInterval(() => {}, 1_000);\n');
+	const controller = new AbortController();
+	let reader: ChildProcess | undefined;
+	const delayedLaunch = async (
+		_temporaryRoot: string,
+		file: string,
+		args: string[],
+		options: NonNullable<Parameters<typeof spawnCross>[2]>
+	): Promise<ChildProcess> => {
+		controller.abort('during PnP reader setup');
+		await Promise.resolve();
+		reader = spawnCross(file, args, options);
+		return reader;
+	};
+	try {
+		await expect(
+			resolveInstalledPackageManifest('astro', project, undefined, controller.signal, delayedLaunch)
+		).rejects.toMatchObject({ name: 'AbortError' });
+		expect(reader?.pid).toBeTypeOf('number');
+		expect(() => process.kill(reader!.pid!, 0)).toThrow(/ESRCH/);
+
+		await writeFile(
+			join(project, '.yarn/releases/reader.cjs'),
+			"process.stdout.write(JSON.stringify({ name: 'astro', version: '7.0.0' }));\n"
+		);
+		await expect(resolveInstalledPackageManifest('astro', project)).resolves.toBe(
+			join(packageRoot, 'package.json')
+		);
+	} finally {
+		await terminateChildProcess(reader);
+	}
+});
+
 describe('selectLatestAstroReleaseTag', () => {
 	test('selects the newest stable tag within the installed Astro major', () => {
 		expect(

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -788,42 +788,61 @@ describe('isolatedBootstrapEnvironment', () => {
 		).toEqual({ COREPACK_HOME: '/cache/corepack' });
 	});
 
-	test('preserves unrelated Node options while removing all loader hook forms', () => {
-		expect(
-			isolatedBootstrapEnvironment({
-				NODE_OPTIONS:
-					'--max-old-space-size=4096 --require "/project/.pnp.cjs" -r=./register.cjs --import "./instrumentation.mjs" --loader=./loader.mjs --experimental-loader "./legacy loader.mjs" --conditions="development test" --trace-warnings',
-			})
-		).toEqual({
-			NODE_OPTIONS: '--max-old-space-size=4096 --conditions="development test" --trace-warnings',
+	test('removes loader hooks while preserving raw surrounding whitespace', async () => {
+		const nodeOptions =
+			'  --trace-warnings --require "./project hook.cjs"  --conditions="development test"  ';
+		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
+
+		expect(environment).toEqual({
+			NODE_OPTIONS: '  --trace-warnings    --conditions="development test"  ',
 		});
+		await expect(
+			runCommand(process.execPath, ['--version'], process.cwd(), environment)
+		).resolves.toMatch(/^v/);
 	});
 
-	test('removes quoted loader option spellings while preserving quoted non-loaders', () => {
-		expect(
-			isolatedBootstrapEnvironment({
-				NODE_OPTIONS:
-					'"--require=C:\\project\\double.cjs" \'--import=./single.mjs\' "--loader" "./double-loader.mjs" \'--experimental-loader\' \'./single-loader.mjs\' \'--experimental_loader=./single-alias.mjs\' "--experimental_loader" "./double-alias.mjs" "--require"="./double mixed.cjs" \'--experimental_loader\'="./single mixed.mjs" "--max-old-space-size=4096" \'--conditions=development\'',
-			})
-		).toEqual({
-			NODE_OPTIONS: '"--max-old-space-size=4096" \'--conditions=development\'',
-		});
+	test('preserves a no-loader Node options string byte-for-byte', async () => {
+		const nodeOptions = '  --conditions="foo\\" bar"   --trace-warnings  ';
+		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
+
+		expect(environment).toEqual({ NODE_OPTIONS: nodeOptions });
+		await expect(
+			runCommand(process.execPath, ['--version'], process.cwd(), environment)
+		).resolves.toMatch(/^v/);
 	});
 
-	test('preserves escaped quotes inside retained Node options', () => {
-		const nodeOptions = '--conditions="foo\\" bar" --trace-warnings';
-
-		expect(isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions })).toEqual({
-			NODE_OPTIONS: nodeOptions,
+	test('removes a loader after an unmatched literal single quote', async () => {
+		const environment = isolatedBootstrapEnvironment({
+			NODE_OPTIONS: "--conditions='foo --require ./project-hook.cjs --trace-warnings",
 		});
+
+		expect(environment).toEqual({ NODE_OPTIONS: "--conditions='foo   --trace-warnings" });
+		await expect(
+			runCommand(process.execPath, ['--version'], process.cwd(), environment)
+		).resolves.toMatch(/^v/);
 	});
 
-	test('removes a loader token containing an escaped quote without retaining its tail', () => {
-		expect(
-			isolatedBootstrapEnvironment({
-				NODE_OPTIONS: '--require="/tmp/hook\\" name.cjs" --trace-warnings',
-			})
-		).toEqual({ NODE_OPTIONS: '--trace-warnings' });
+	test('preserves single-quoted loader names without classifying them as hooks', async () => {
+		const nodeOptions = "'--require' ./project-hook.cjs --trace-warnings";
+		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
+
+		expect(environment).toEqual({ NODE_OPTIONS: nodeOptions });
+		await expect(
+			runCommand(process.execPath, ['--version'], process.cwd(), environment)
+		).resolves.toMatch(/^v/);
+	});
+
+	test.each([
+		['tab', '\t'],
+		['newline', '\n'],
+	])('preserves Node-rejected %s separators', async (_name, separator) => {
+		const nodeOptions = `--trace-warnings${separator}--conditions=foo`;
+		const environment = isolatedBootstrapEnvironment({ NODE_OPTIONS: nodeOptions });
+
+		expect(environment).toEqual({ NODE_OPTIONS: nodeOptions });
+		await expect(
+			runCommand(process.execPath, ['--version'], process.cwd(), environment)
+		).rejects.toThrow('not allowed in NODE_OPTIONS');
 	});
 
 	test('preserves malformed Node options for Node to reject', async () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -1,6 +1,16 @@
-import { spawn as spawnChild } from 'node:child_process';
+import { type ChildProcess, spawn as spawnChild } from 'node:child_process';
 import { once } from 'node:events';
-import { mkdir, mkdtemp, readlink, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import {
+	chmod,
+	mkdir,
+	mkdtemp,
+	readFile,
+	readlink,
+	readdir,
+	rm,
+	symlink,
+	writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
@@ -166,6 +176,37 @@ describe('terminateChildProcess', () => {
 			expect(() => process.kill(-pid, 0)).toThrow(/ESRCH/);
 		}
 	);
+
+	test('shares Windows taskkill across concurrent and late stop requests', async () => {
+		const root = await temporaryRoot();
+		const bin = join(root, 'bin');
+		const log = join(root, 'taskkill.log');
+		const taskkill = join(bin, 'taskkill');
+		await mkdir(bin);
+		await writeFile(taskkill, '#!/bin/sh\nprintf "%s\\n" "$@" >> "$TASKKILL_LOG"\nsleep 0.05\n');
+		await chmod(taskkill, 0o755);
+
+		const originalPath = process.env.PATH;
+		const originalLog = process.env.TASKKILL_LOG;
+		process.env.PATH = `${bin}:${originalPath ?? ''}`;
+		process.env.TASKKILL_LOG = log;
+		try {
+			const child = { pid: process.pid } as ChildProcess;
+			const first = terminateChildProcess(child, 'win32');
+			const second = terminateChildProcess(child, 'win32');
+
+			expect(second).toBe(first);
+			await Promise.all([first, second]);
+			await terminateChildProcess(child, 'win32');
+
+			expect((await readFile(log, 'utf8')).match(/^\/pid$/gm) ?? []).toHaveLength(1);
+		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			if (originalLog === undefined) delete process.env.TASKKILL_LOG;
+			else process.env.TASKKILL_LOG = originalLog;
+		}
+	});
 });
 
 describe('detectPackageManager', () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -4,10 +4,12 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
 import {
 	collectInstalledDependencyNames,
+	createRuntimeDependencies,
 	detectPackageManager,
 	discoverAstroWorkspacePackages,
-	resolveInstalledPackageManifest,
 	installedAstroMajor,
+	packageLinkCommands,
+	resolveInstalledPackageManifest,
 } from '../src/runtime.js';
 
 const temporaryRoots: string[] = [];
@@ -75,6 +77,59 @@ describe('detectPackageManager', () => {
 			await expect(detectPackageManager(project)).resolves.toBe(manager);
 		}
 	);
+});
+
+describe('packageLinkCommands', () => {
+	test('uses local folder dependencies for Bun without touching its global link registry', () => {
+		const project = '/project';
+		const links = [
+			{ name: 'astro', path: '/checkout/packages/astro' },
+			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler' },
+		];
+
+		expect(packageLinkCommands('bun', false, project, links)).toEqual([
+			{
+				command: ['bun', 'add', '--no-save', ...links.map(({ path }) => path)],
+				cwd: project,
+			},
+		]);
+	});
+
+	test('uses the Classic Yarn link protocol entirely from the target project', () => {
+		const project = '/project';
+		const links = [
+			{ name: 'astro', path: '/checkout/packages/astro' },
+			{ name: '@astrojs/compiler', path: '/checkout/packages/compiler' },
+		];
+
+		expect(packageLinkCommands('yarn', false, project, links)).toEqual([
+			{
+				command: [
+					'yarn',
+					'add',
+					'--pure-lockfile',
+					'--ignore-workspace-root-check',
+					...links.map(({ path }) => `link:${path}`),
+				],
+				cwd: project,
+			},
+		]);
+	});
+});
+
+describe('createRuntimeDependencies', () => {
+	test('refuses to start a session without a restorable lockfile', async () => {
+		const project = await createProject({
+			packageManager: 'npm@11.4.2',
+			dependencies: { astro: '^7.0.0' },
+		});
+		await writePackage(project, 'node_modules/astro', { name: 'astro', version: '7.0.0' });
+		const dependencies = await createRuntimeDependencies(project, new AbortController().signal);
+
+		await expect(dependencies.createSession()).rejects.toThrow(
+			'every-astro requires a npm lockfile to restore the exact dependency tree'
+		);
+	});
 });
 
 describe('discoverAstroWorkspacePackages', () => {

--- a/packages/every-astro/tests/runtime.test.ts
+++ b/packages/every-astro/tests/runtime.test.ts
@@ -223,6 +223,86 @@ test('aborts a PnP reader launched after setup starts without caching its manife
 	}
 });
 
+test.skipIf(process.platform === 'win32')(
+	'aborts while successful PnP reader descendant cleanup is pending without caching',
+	async () => {
+		const project = await createProject({
+			packageManager: 'yarn@4.17.1',
+			dependencies: { astro: '7.0.0' },
+		});
+		const pidDirectory = join(project, 'reader-pids');
+		const packageRoot = join(project, '.yarn/cache/astro.zip/node_modules/astro');
+		await mkdir(pidDirectory, { recursive: true });
+		await mkdir(join(project, '.yarn/cache'), { recursive: true });
+		await writeFile(join(project, '.yarn/cache/astro.zip'), '');
+		await writeFile(
+			join(project, '.pnp.cjs'),
+			`exports.resolveToUnqualified = (request) => request === 'astro' ? ${JSON.stringify(packageRoot)} : null;\n`
+		);
+		await writeFile(
+			join(project, '.yarnrc.yml'),
+			'yarnPath: .yarn/releases/reader.cjs\nnodeLinker: pnp\n'
+		);
+		await mkdir(join(project, '.yarn/releases'), { recursive: true });
+		// The unrefed child deliberately survives its successful reader until cleanup owns it.
+		await writeFile(
+			join(project, '.yarn/releases/reader.cjs'),
+			[
+				"const { spawn } = require('node:child_process');",
+				"const { writeFileSync } = require('node:fs');",
+				"const { join } = require('node:path');",
+				'const directory = process.env.EVERY_ASTRO_PNP_READER_PIDS;',
+				"const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], { stdio: 'ignore' });",
+				'descendant.unref();',
+				"writeFileSync(join(directory, `reader-${process.pid}`), '');",
+				"writeFileSync(join(directory, `descendant-${descendant.pid}`), '');",
+				"process.stdout.write(JSON.stringify({ name: 'astro', version: '7.0.0' }));",
+			].join('\n')
+		);
+		const previousPidDirectory = process.env.EVERY_ASTRO_PNP_READER_PIDS;
+		process.env.EVERY_ASTRO_PNP_READER_PIDS = pidDirectory;
+		const controller = new AbortController();
+		const cleanupStarted = Promise.withResolvers<void>();
+		const cleanupRelease = Promise.withResolvers<void>();
+		const pausedTerminator = async (child: ChildProcess | undefined): Promise<void> => {
+			cleanupStarted.resolve();
+			await cleanupRelease.promise;
+			await terminateChildProcess(child);
+		};
+		try {
+			const manifest = resolveInstalledPackageManifest(
+				'astro',
+				project,
+				undefined,
+				controller.signal,
+				undefined,
+				pausedTerminator
+			);
+			await cleanupStarted.promise;
+			controller.abort('during PnP reader cleanup');
+			cleanupRelease.resolve();
+
+			await expect(manifest).rejects.toMatchObject({ name: 'AbortError' });
+			const pids = (await readdir(pidDirectory))
+				.map((entry) => Number(entry.slice(entry.lastIndexOf('-') + 1)))
+				.filter(Number.isSafeInteger);
+			expect(pids).toHaveLength(2);
+			for (const pid of pids) {
+				expect(() => process.kill(pid, 0)).toThrow(/ESRCH/);
+			}
+
+			await expect(resolveInstalledPackageManifest('astro', project)).resolves.toBe(
+				join(packageRoot, 'package.json')
+			);
+			expect(await readdir(pidDirectory)).toHaveLength(4);
+		} finally {
+			cleanupRelease.resolve();
+			if (previousPidDirectory === undefined) delete process.env.EVERY_ASTRO_PNP_READER_PIDS;
+			else process.env.EVERY_ASTRO_PNP_READER_PIDS = previousPidDirectory;
+		}
+	}
+);
+
 describe('selectLatestAstroReleaseTag', () => {
 	test('selects the newest stable tag within the installed Astro major', () => {
 		expect(

--- a/packages/every-astro/tests/workflow.test.ts
+++ b/packages/every-astro/tests/workflow.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test, vi } from 'vitest';
+import { runEveryAstro, type BisectSession, type EveryAstroDependencies } from '../src/workflow.js';
+
+class FakeSession implements BisectSession {
+	readonly events: string[] = [];
+	readonly prepareRevision = vi.fn(async (_revision: string) => {});
+	readonly runDevServerAndAsk = vi.fn(async (_label: string) => false);
+	readonly startBisect = vi.fn(async (_good: string, _bad: string) => {});
+	readonly currentRevision = vi.fn(async () => 'candidate');
+	readonly markCurrent = vi.fn<(isBad: boolean) => Promise<string | undefined>>(
+		async (_isBad) => undefined
+	);
+	readonly close = vi.fn(async () => {
+		this.events.push('close');
+	});
+	readonly latestRevision = vi.fn(async () => 'latest-sha');
+}
+
+function dependencies(session: FakeSession, astroMajor = 6) {
+	const logs: string[] = [];
+	const deps: EveryAstroDependencies = {
+		installedAstroMajor: vi.fn(async () => astroMajor),
+		createSession: vi.fn(async () => session),
+		log: (message) => {
+			session.events.push(`log:${message}`);
+			logs.push(message);
+		},
+	};
+
+	return { deps, logs };
+}
+
+describe('runEveryAstro', () => {
+	test('stops after the latest revision is good and reports that the bug is fixed', async () => {
+		const session = new FakeSession();
+		session.runDevServerAndAsk.mockResolvedValue(false);
+		const { deps, logs } = dependencies(session);
+
+		await runEveryAstro(deps);
+
+		expect(session.prepareRevision).toHaveBeenCalledExactlyOnceWith('latest-sha');
+		expect(session.runDevServerAndAsk).toHaveBeenCalledExactlyOnceWith('latest');
+		expect(session.startBisect).not.toHaveBeenCalled();
+		expect(session.markCurrent).not.toHaveBeenCalled();
+		expect(logs).toEqual(['The bug is already fixed in the latest Astro revision.']);
+		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(session.events).toEqual([
+			'close',
+			'log:The bug is already fixed in the latest Astro revision.',
+		]);
+	});
+
+	test('stops when the first release of the installed major is bad and reports that it predates the major', async () => {
+		const session = new FakeSession();
+		session.runDevServerAndAsk.mockResolvedValue(true);
+		const { deps, logs } = dependencies(session, 7);
+
+		await runEveryAstro(deps);
+
+		expect(session.prepareRevision).toHaveBeenNthCalledWith(1, 'latest-sha');
+		expect(session.prepareRevision).toHaveBeenNthCalledWith(2, 'astro@7.0.0');
+		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(1, 'latest');
+		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(2, 'v7.0.0');
+		expect(session.startBisect).not.toHaveBeenCalled();
+		expect(session.markCurrent).not.toHaveBeenCalled();
+		expect(logs).toEqual(['The bug predates Astro v7.']);
+		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(session.events).toEqual(['close', 'log:The bug predates Astro v7.']);
+	});
+
+	test('bisects between the first good release and latest bad revision, then reports the exact first bad commit', async () => {
+		const session = new FakeSession();
+		session.currentRevision
+			.mockResolvedValueOnce('candidate-a')
+			.mockResolvedValueOnce('candidate-b');
+		session.runDevServerAndAsk
+			.mockResolvedValueOnce(true)
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true)
+			.mockResolvedValueOnce(false);
+		session.markCurrent.mockResolvedValueOnce(undefined).mockResolvedValueOnce('first-bad-sha');
+		const { deps, logs } = dependencies(session, 5);
+
+		await runEveryAstro(deps);
+
+		expect(session.startBisect).toHaveBeenCalledExactlyOnceWith('astro@5.0.0', 'latest-sha');
+		expect(session.prepareRevision).toHaveBeenNthCalledWith(1, 'latest-sha');
+		expect(session.prepareRevision).toHaveBeenNthCalledWith(2, 'astro@5.0.0');
+		expect(session.prepareRevision).toHaveBeenNthCalledWith(3, 'candidate-a');
+		expect(session.prepareRevision).toHaveBeenNthCalledWith(4, 'candidate-b');
+		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(1, 'latest');
+		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(2, 'v5.0.0');
+		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(3, 'candidate-a');
+		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(4, 'candidate-b');
+		expect(session.markCurrent).toHaveBeenNthCalledWith(1, true);
+		expect(session.markCurrent).toHaveBeenNthCalledWith(2, false);
+		expect(logs).toEqual(['The bug was introduced in Astro commit first-bad-sha.']);
+		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(session.events).toEqual([
+			'close',
+			'log:The bug was introduced in Astro commit first-bad-sha.',
+		]);
+	});
+
+	type FailureCase = {
+		name: string;
+		configure(session: FakeSession): void;
+	};
+
+	test.each<FailureCase>([
+		{
+			name: 'preparing a revision',
+			configure: (session: FakeSession) => {
+				session.prepareRevision.mockRejectedValueOnce(new Error('prepare failed'));
+			},
+		},
+		{
+			name: 'asking about the dev server',
+			configure: (session: FakeSession) => {
+				session.runDevServerAndAsk.mockRejectedValueOnce(new Error('prompt failed'));
+			},
+		},
+		{
+			name: 'marking a bisect revision',
+			configure: (session: FakeSession) => {
+				session.runDevServerAndAsk
+					.mockResolvedValueOnce(true)
+					.mockResolvedValueOnce(false)
+					.mockResolvedValueOnce(true);
+				session.markCurrent.mockRejectedValueOnce(new Error('mark failed'));
+			},
+		},
+	])('closes the session when $name throws', async ({ configure }) => {
+		const session = new FakeSession();
+		configure(session);
+		const { deps, logs } = dependencies(session);
+
+		await expect(runEveryAstro(deps)).rejects.toThrow(/failed/);
+
+		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(logs).toEqual([]);
+		expect(session.events).toEqual(['close']);
+	});
+
+	test('rejects without a result log when session cleanup fails', async () => {
+		const session = new FakeSession();
+		session.runDevServerAndAsk.mockResolvedValue(false);
+		session.close.mockImplementation(async () => {
+			session.events.push('close');
+			throw new Error('cleanup failed');
+		});
+		const { deps, logs } = dependencies(session);
+
+		await expect(runEveryAstro(deps)).rejects.toThrow('cleanup failed');
+
+		expect(logs).toEqual([]);
+		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(session.events).toEqual(['close']);
+	});
+});

--- a/packages/every-astro/tests/workflow.test.ts
+++ b/packages/every-astro/tests/workflow.test.ts
@@ -59,7 +59,7 @@ describe('runEveryAstro', () => {
 		]);
 	});
 
-	test('stops when the inclusive first release is bad and reports that the introduction is outside the selected range', async () => {
+	test('stops when the inclusive first release is bad and reports the first-release boundary', async () => {
 		const session = new FakeSession();
 		session.runDevServerAndAsk.mockResolvedValue(true);
 		const { deps, logs } = dependencies(session, 7);
@@ -73,12 +73,12 @@ describe('runEveryAstro', () => {
 		expect(session.startBisect).not.toHaveBeenCalled();
 		expect(session.markCurrent).not.toHaveBeenCalled();
 		expect(logs).toEqual([
-			'The bug is already present in Astro v7.0.0; its introduction is outside the selected major range.',
+			'The bug is already present in Astro v7.0.0; its introduction is at or before the first-release boundary, and earlier history is not bisected.',
 		]);
 		expect(session.close).toHaveBeenCalledExactlyOnceWith();
 		expect(session.events).toEqual([
 			'close',
-			'log:The bug is already present in Astro v7.0.0; its introduction is outside the selected major range.',
+			'log:The bug is already present in Astro v7.0.0; its introduction is at or before the first-release boundary, and earlier history is not bisected.',
 		]);
 	});
 

--- a/packages/every-astro/tests/workflow.test.ts
+++ b/packages/every-astro/tests/workflow.test.ts
@@ -22,9 +22,10 @@ class FakeSession implements BisectSession {
 	readonly latestRevision = vi.fn(async () => 'latest-sha');
 }
 
-function dependencies(session: FakeSession, astroMajor = 6) {
+function dependencies(session: FakeSession, astroMajor = 6, signal = new AbortController().signal) {
 	const logs: string[] = [];
 	const deps: EveryAstroDependencies = {
+		signal,
 		installedAstroMajor: vi.fn(async () => astroMajor),
 		createSession: vi.fn(async () => session),
 		log: (message) => {
@@ -169,6 +170,86 @@ describe('runEveryAstro', () => {
 		expect(logs).toEqual([]);
 		expect(session.close).toHaveBeenCalledExactlyOnceWith();
 		expect(session.events).toEqual(['close']);
+	});
+
+	test('reports an abort that arrives during successful cleanup without logging a result', async () => {
+		const session = new FakeSession();
+		const controller = new AbortController();
+		session.runDevServerAndAsk.mockResolvedValue(false);
+		session.close.mockImplementation(async () => {
+			session.events.push('close');
+			controller.abort();
+		});
+		const { deps, logs } = dependencies(session, 6, controller.signal);
+
+		const error = await runEveryAstro(deps).catch((error: unknown) => error);
+
+		expect(isPlainAbortError(error)).toBe(true);
+		expect(logs).toEqual([]);
+		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(session.events).toEqual(['close']);
+	});
+
+	test('keeps cleanup failure precedence when an abort arrives during cleanup', async () => {
+		const session = new FakeSession();
+		const controller = new AbortController();
+		const cleanupError = new Error('cleanup failed');
+		session.runDevServerAndAsk.mockResolvedValue(false);
+		session.close.mockImplementation(async () => {
+			session.events.push('close');
+			controller.abort();
+			throw cleanupError;
+		});
+		const { deps, logs } = dependencies(session, 6, controller.signal);
+
+		const error = await runEveryAstro(deps).catch((error: unknown) => error);
+
+		expect(error).toBe(cleanupError);
+		expect(isPlainAbortError(error)).toBe(false);
+		expect(logs).toEqual([]);
+		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(session.events).toEqual(['close']);
+	});
+
+	test('defers the single cleanup until an aborted inter-revision restoration completes', async () => {
+		const session = new FakeSession();
+		const controller = new AbortController();
+		let activePackageManagerOperations = 0;
+		let maximumConcurrentPackageManagerOperations = 0;
+		const beginPackageManagerOperation = (): void => {
+			activePackageManagerOperations += 1;
+			maximumConcurrentPackageManagerOperations = Math.max(
+				maximumConcurrentPackageManagerOperations,
+				activePackageManagerOperations
+			);
+		};
+		session.runDevServerAndAsk.mockResolvedValue(true);
+		session.prepareRevision.mockImplementation(async (revision) => {
+			if (revision !== 'astro@6.0.0') return;
+			session.events.push('restore:start');
+			beginPackageManagerOperation();
+			controller.abort();
+			await Promise.resolve();
+			activePackageManagerOperations -= 1;
+			session.events.push('restore:end');
+		});
+		session.close.mockImplementation(async () => {
+			expect(activePackageManagerOperations).toBe(0);
+			session.events.push('close:start');
+			beginPackageManagerOperation();
+			await Promise.resolve();
+			activePackageManagerOperations -= 1;
+			session.events.push('close:end');
+		});
+		const { deps, logs } = dependencies(session, 6, controller.signal);
+
+		const error = await runEveryAstro(deps).catch((error: unknown) => error);
+
+		expect(isPlainAbortError(error)).toBe(true);
+		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(maximumConcurrentPackageManagerOperations).toBe(1);
+		expect(session.events).toEqual(['restore:start', 'restore:end', 'close:start', 'close:end']);
+		expect(logs).toEqual([]);
 	});
 	test('preserves the workflow failure when session cleanup also fails', async () => {
 		const session = new FakeSession();

--- a/packages/every-astro/tests/workflow.test.ts
+++ b/packages/every-astro/tests/workflow.test.ts
@@ -37,7 +37,7 @@ function dependencies(session: FakeSession, astroMajor = 6) {
 }
 
 describe('runEveryAstro', () => {
-	test('stops after the latest revision is good and reports that the bug is fixed', async () => {
+	test('stops after the latest installed-major revision is good and reports that the bug is fixed', async () => {
 		const session = new FakeSession();
 		session.runDevServerAndAsk.mockResolvedValue(false);
 		const { deps, logs } = dependencies(session);
@@ -45,18 +45,20 @@ describe('runEveryAstro', () => {
 		await runEveryAstro(deps);
 
 		expect(session.prepareRevision).toHaveBeenCalledExactlyOnceWith('latest-sha');
-		expect(session.runDevServerAndAsk).toHaveBeenCalledExactlyOnceWith('latest');
+		expect(session.runDevServerAndAsk).toHaveBeenCalledExactlyOnceWith('latest v6');
 		expect(session.startBisect).not.toHaveBeenCalled();
 		expect(session.markCurrent).not.toHaveBeenCalled();
-		expect(logs).toEqual(['The bug is already fixed in the latest Astro revision.']);
+		expect(logs).toEqual([
+			'The bug is already fixed in the latest Astro revision in the installed major (v6).',
+		]);
 		expect(session.close).toHaveBeenCalledExactlyOnceWith();
 		expect(session.events).toEqual([
 			'close',
-			'log:The bug is already fixed in the latest Astro revision.',
+			'log:The bug is already fixed in the latest Astro revision in the installed major (v6).',
 		]);
 	});
 
-	test('stops when the first release of the installed major is bad and reports that it predates the major', async () => {
+	test('stops when the inclusive first release is bad and reports that the introduction is outside the selected range', async () => {
 		const session = new FakeSession();
 		session.runDevServerAndAsk.mockResolvedValue(true);
 		const { deps, logs } = dependencies(session, 7);
@@ -65,16 +67,21 @@ describe('runEveryAstro', () => {
 
 		expect(session.prepareRevision).toHaveBeenNthCalledWith(1, 'latest-sha');
 		expect(session.prepareRevision).toHaveBeenNthCalledWith(2, 'astro@7.0.0');
-		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(1, 'latest');
+		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(1, 'latest v7');
 		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(2, 'v7.0.0');
 		expect(session.startBisect).not.toHaveBeenCalled();
 		expect(session.markCurrent).not.toHaveBeenCalled();
-		expect(logs).toEqual(['The bug predates Astro v7.']);
+		expect(logs).toEqual([
+			'The bug is already present in Astro v7.0.0; its introduction is outside the selected major range.',
+		]);
 		expect(session.close).toHaveBeenCalledExactlyOnceWith();
-		expect(session.events).toEqual(['close', 'log:The bug predates Astro v7.']);
+		expect(session.events).toEqual([
+			'close',
+			'log:The bug is already present in Astro v7.0.0; its introduction is outside the selected major range.',
+		]);
 	});
 
-	test('bisects between the first good release and latest bad revision, then reports the exact first bad commit', async () => {
+	test('bisects between the inclusive first release and latest installed-major revision, then reports the exact first bad commit', async () => {
 		const session = new FakeSession();
 		session.currentRevision
 			.mockResolvedValueOnce('candidate-a')
@@ -94,7 +101,7 @@ describe('runEveryAstro', () => {
 		expect(session.prepareRevision).toHaveBeenNthCalledWith(2, 'astro@5.0.0');
 		expect(session.prepareRevision).toHaveBeenNthCalledWith(3, 'candidate-a');
 		expect(session.prepareRevision).toHaveBeenNthCalledWith(4, 'candidate-b');
-		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(1, 'latest');
+		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(1, 'latest v5');
 		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(2, 'v5.0.0');
 		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(3, 'candidate-a');
 		expect(session.runDevServerAndAsk).toHaveBeenNthCalledWith(4, 'candidate-b');

--- a/packages/every-astro/tests/workflow.test.ts
+++ b/packages/every-astro/tests/workflow.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test, vi } from 'vitest';
-import { runEveryAstro, type BisectSession, type EveryAstroDependencies } from '../src/workflow.js';
+import {
+	isPlainAbortError,
+	runEveryAstro,
+	WorkflowCleanupError,
+	type BisectSession,
+	type EveryAstroDependencies,
+} from '../src/workflow.js';
 
 class FakeSession implements BisectSession {
 	readonly events: string[] = [];
@@ -155,6 +161,69 @@ describe('runEveryAstro', () => {
 
 		expect(logs).toEqual([]);
 		expect(session.close).toHaveBeenCalledExactlyOnceWith();
+		expect(session.events).toEqual(['close']);
+	});
+	test('preserves the workflow failure when session cleanup also fails', async () => {
+		const session = new FakeSession();
+		const primaryError = new Error('prepare failed');
+		const cleanupError = new Error('cleanup failed');
+		session.prepareRevision.mockRejectedValueOnce(primaryError);
+		session.close.mockImplementation(async () => {
+			session.events.push('close');
+			throw cleanupError;
+		});
+		const { deps, logs } = dependencies(session);
+
+		const error = await runEveryAstro(deps).catch((error: unknown) => error);
+
+		expect(error).toBeInstanceOf(WorkflowCleanupError);
+		expect(error).toMatchObject({
+			cause: primaryError,
+			cleanupError,
+			primaryError,
+		});
+		expect((error as WorkflowCleanupError).errors).toEqual([primaryError, cleanupError]);
+		expect(logs).toEqual([]);
+		expect(session.events).toEqual(['close']);
+	});
+
+	test('makes a plain abort interruption suppressible', async () => {
+		const session = new FakeSession();
+		const abortError = new Error('interrupted');
+		abortError.name = 'AbortError';
+		session.prepareRevision.mockRejectedValueOnce(abortError);
+		const { deps, logs } = dependencies(session);
+
+		const error = await runEveryAstro(deps).catch((error: unknown) => error);
+
+		expect(error).toBe(abortError);
+		expect(isPlainAbortError(error)).toBe(true);
+		expect(logs).toEqual([]);
+		expect(session.events).toEqual(['close']);
+	});
+
+	test('keeps cleanup failures reportable when an interruption also fails cleanup', async () => {
+		const session = new FakeSession();
+		const abortError = new Error('interrupted');
+		abortError.name = 'AbortError';
+		const cleanupError = new Error('cleanup failed');
+		session.prepareRevision.mockRejectedValueOnce(abortError);
+		session.close.mockImplementation(async () => {
+			session.events.push('close');
+			throw cleanupError;
+		});
+		const { deps, logs } = dependencies(session);
+
+		const error = await runEveryAstro(deps).catch((error: unknown) => error);
+
+		expect(error).toBeInstanceOf(WorkflowCleanupError);
+		expect(isPlainAbortError(error)).toBe(false);
+		expect(error).toMatchObject({
+			cause: abortError,
+			cleanupError,
+			primaryError: abortError,
+		});
+		expect(logs).toEqual([]);
 		expect(session.events).toEqual(['close']);
 	});
 });

--- a/packages/every-astro/tsconfig.json
+++ b/packages/every-astro/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/every-astro/tsup.config.ts
+++ b/packages/every-astro/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	format: ['esm'],
+	target: 'node22',
+	banner: { js: '#!/usr/bin/env node' },
+	bundle: true,
+	sourcemap: true,
+	clean: true,
+	splitting: true,
+	minify: true,
+	treeshake: 'smallest',
+	tsconfig: 'tsconfig.json',
+});

--- a/packages/every-astro/vitest.config.mjs
+++ b/packages/every-astro/vitest.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+process.env.NODE_OPTIONS ??= '--enable-source-maps';
+process.setSourceMapsEnabled(true);
+
+export default defineConfig({
+	keepProcessEnv: true,
+	test: {
+		testTimeout: 30_000,
+	},
+	dev: {
+		sourcemap: true,
+	},
+	build: {
+		sourcemap: 'inline',
+	},
+});

--- a/packages/request-state/e2e/dev.spec.ts
+++ b/packages/request-state/e2e/dev.spec.ts
@@ -18,24 +18,12 @@ test.afterAll(async () => {
 
 test('apply new as edited during development', async ({ page }) => {
 	const pageUrl = fixture.resolveUrl('/');
+	const state = page.locator('pre#state');
 
 	await page.goto(pageUrl);
-	await expect
-		.poll(async () => {
-			const state = JSON.parse(await page.locator('pre#state').innerHTML());
-
-			console.log(state);
-			return state;
-		})
-		.toStrictEqual({
-			source: 'Original',
-		});
+	await expect(state).toHaveText(JSON.stringify({ source: 'Original' }, null, 2));
 
 	await fixture.editFile('./src/state.ts', (code) => (code ?? '').replace('Original', 'Updated'));
 
-	await expect
-		.poll(async () => JSON.parse(await page.locator('pre#state').innerHTML()))
-		.toStrictEqual({
-			source: 'Updated',
-		});
+	await expect(state).toHaveText(JSON.stringify({ source: 'Updated' }, null, 2));
 });

--- a/packages/request-state/e2e/view-transitions.spec.ts
+++ b/packages/request-state/e2e/view-transitions.spec.ts
@@ -22,9 +22,9 @@ test('apply new state after view transition', async ({ page }) => {
 	const pageUrl = fixture.resolveUrl('/?name=Emily');
 
 	await page.goto(pageUrl);
-	expect(page.locator('#name')).toHaveText('Emily');
+	await expect(page.locator('#name')).toHaveText('Emily');
 
 	await page.locator('a').click();
 	await expect(page).toHaveURL(fixture.resolveUrl('/?name=John'));
-	expect(page.locator('#name')).toHaveText('John');
+	await expect(page.locator('#name')).toHaveText('John');
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,10 +603,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.1.4
-        version: 8.1.4(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0)
+        version: 8.1.4(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
+        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
 
   packages/astro-when:
     dependencies:
@@ -838,7 +838,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
+        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
 
   packages/inline-mod:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,12 @@ catalogs:
     content-type:
       specifier: ^1.0.5
       version: 1.0.5
+    corepack:
+      specifier: 0.34.0
+      version: 0.34.0
+    cross-spawn:
+      specifier: 7.0.6
+      version: 7.0.6
     debug:
       specifier: ^4.4.3
       version: 4.4.3
@@ -597,10 +603,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.1.4
-        version: 8.1.4(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0)
+        version: 8.1.4(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
+        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
 
   packages/astro-when:
     dependencies:
@@ -811,6 +817,28 @@ importers:
       astro:
         specifier: ^7.0.7
         version: 7.0.7(patch_hash=34ac88963a271f59948954a697fdf4850409d163faae6f020d77c206005cacc4)(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.4)(@vercel/functions@3.7.2)(db0@0.3.4)(ioredis@5.8.2)(jiti@2.6.1)(rollup@4.62.2)(terser@5.44.1)(yaml@2.9.0)
+
+  packages/every-astro:
+    dependencies:
+      corepack:
+        specifier: 'catalog:'
+        version: 0.34.0
+      cross-spawn:
+        specifier: 'catalog:'
+        version: 7.0.6
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.4
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.19)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
 
   packages/inline-mod:
     dependencies:
@@ -3937,6 +3965,11 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  corepack@0.34.0:
+    resolution: {integrity: sha512-8D9N/k9hDjoISCDGUzH2wBF0fJD49p3G7ifoEZcc0vhB7Py6r+Mc1SpJ8dvnWY/HMP95K60WkQbN7vgbUgXgpA==}
+    engines: {node: ^20.10.0 || ^22.11.0 || >=24.0.0}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -8874,6 +8907,8 @@ snapshots:
   cookie-es@1.2.3: {}
 
   cookie@1.1.1: {}
+
+  corepack@0.34.0: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -830,6 +830,16 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.4
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.19)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(vite@8.1.4(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.9.0))
+
   packages/git-redirect:
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,8 @@ catalog:
   ast-types: ^0.14.2
   astro: ^7.0.7
   content-type: ^1.0.5
+  corepack: 0.34.0
+  cross-spawn: 7.0.6
   debug: ^4.4.3
   devalue: ^5.6.3
   estree-walker: ^3.0.3


### PR DESCRIPTION
## Intent

Implement a new publishable @inox-tools/every-astro CLI that runs inside an Astro project and identifies the Astro commit that introduced a user-observed bug. It must determine the installed Astro major, clone the full Astro repository to a temporary directory, build and link or install every Astro monorepo package used by the project, test latest and the first release of that major by running the project's dev server and asking whether the bug is present, stop with fixed or predates-major messages when applicable, and otherwise drive git bisect until the exact first bad commit is identified. Use Astro's real astro@<major>.0.0 Git ref while displaying v<major>.0.0 to users; support pnpm, npm, Yarn Classic/Berry/PnP, and Bun; use Node >=22.12, bundled Corepack, and Windows-safe process spawning; recompute available linked packages per revision; and always restore manifests, lockfiles, dependencies, links, processes, bisect state, and temporary files before reporting success.

## What Changed

- Add a publishable interactive CLI that tests Astro revisions against a project’s dev server and uses `git bisect` to identify the first bad commit.
- Support pnpm, npm, Yarn Classic/Berry/PnP, and Bun projects, with revision-specific Astro package substitution and cleanup/restoration handling.
- Add package configuration, unit coverage, documentation, and a minor changeset for `@inox-tools/every-astro`.

## Risk Assessment

🚨 High: The cleanup path can alter or break the user’s dependency installation, including a deterministic restoration failure on common Windows package-manager layouts.

## Testing

The focused package tests and packed-CLI end-to-end checks passed. Bun and Yarn Berry/PnP both built and activated the selected Astro checkout, reached the interactive result, restored manifests, lockfiles, dependency state, and original Astro behavior, and left no testing residue in the worktree.

<details>
<summary>Evidence: Bun revision activation and restoration</summary>

<code>built fixture Astro&#10;ASTRO_FIXTURE_BEHAVIOR=bad&#10;latest: is the bug present? [y/n] n&#10;The bug is already fixed in the latest Astro revision.&#10;RESTORED_ASTRO_VERSION=7.0.0&#10;RESTORATION_HASHES_MATCH</code>

```text
$ node -e "console.log('built fixture Astro')"
built fixture Astro
ASTRO_FIXTURE_BEHAVIOR=bad
latest: is the bug present? [y/n] n
The bug is already fixed in the latest Astro revision.
RESTORED_ASTRO_VERSION=7.0.0
RESTORATION_HASHES_MATCH
```
</details>
<details>
<summary>Evidence: Yarn Berry/PnP activation and restoration</summary>

<code>built fixture Astro&#10;➤ YN0085: │ + astro@portal:/tmp/every-astro-EhzbwI/astro/packages/astro&#10;latest: is the bug present? [y/n] ASTRO_FIXTURE_BEHAVIOR=bad&#10;The bug is already fixed in the latest Astro revision.&#10;ASTRO_FIXTURE_BEHAVIOR=original-restored&#10;RESTORATION_HASHES_MATCH</code>

```text
$ node -e "console.log('built fixture Astro')"
built fixture Astro
➤ YN0085: │ + astro@portal:/tmp/every-astro-EhzbwI/astro/packages/astro::locator=every-astro-yarn-pnp-consumer%40workspace%3A.
latest: is the bug present? [y/n] ASTRO_FIXTURE_BEHAVIOR=bad
The bug is already fixed in the latest Astro revision.
ASTRO_FIXTURE_BEHAVIOR=original-restored
RESTORATION_HASHES_MATCH
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (37m58s)

