### PR TITLE
feat(docs): warn for unpublished packages

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
 				},
 			],
 			components: {
+				Banner: './src/components/Banner.astro',
 				Head: './src/components/Head.astro',
 				PageTitle: './src/components/PageTitle.astro',
 				Sidebar: './src/components/Sidebar.astro',

--- a/docs/src/components/Banner.astro
+++ b/docs/src/components/Banner.astro
@@ -1,0 +1,37 @@
+---
+import Default from '@astrojs/starlight/components/Banner.astro';
+import { isUnpublishedPackage } from '@/utils/package-versions';
+
+const { packageName } = Astro.locals.starlightRoute.entry.data;
+const isUnpublished = packageName && isUnpublishedPackage(packageName);
+---
+
+{
+	isUnpublished && (
+		<div class="sl-banner unpublished-package-warning" data-pagefind-ignore>
+			<strong>Unpublished package:</strong> This package has not been published to npm yet.
+		</div>
+	)
+}
+
+<Default {...Astro.props}>
+	<slot />
+</Default>
+
+<style>
+	@layer starlight.core {
+		.unpublished-package-warning {
+			--__sl-banner-text: var(--sl-color-banner-text, var(--sl-color-text-invert));
+			padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
+			background-color: var(--sl-color-banner-bg, var(--sl-color-bg-accent));
+			color: var(--__sl-banner-text);
+			line-height: var(--sl-line-height-headings);
+			text-align: center;
+			text-wrap: balance;
+			box-shadow: var(--sl-shadow-sm);
+		}
+		.unpublished-package-warning :global(a) {
+			color: var(--__sl-banner-text);
+		}
+	}
+</style>

--- a/docs/src/components/Version.astro
+++ b/docs/src/components/Version.astro
@@ -1,37 +1,5 @@
 ---
-/*
- * Modified copy from Astro Docs:
- * https://github.com/withastro/docs/blob/35b56b0a76eb0e2f59c13355a88765f76e45609d/src/components/Version.astro
- */
-
-import { simpleFetch } from '@/utils/fetch';
-import { Lazy } from '@inox-tools/utils/lazy';
-import { join } from 'node:path';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-
-export const localPackages = Lazy.of(() => {
-	const packagesDir = new URL('packages/', import.meta.env.ASTRO_PROJECT_ROOT);
-
-	const entries = readdirSync(packagesDir, {
-		recursive: false,
-		encoding: 'utf-8',
-		withFileTypes: true,
-	});
-
-	const packages = new Map<string, string>();
-
-	for (const entry of entries) {
-		if (!entry.isDirectory()) continue;
-
-		const packageJsonPath = join(entry.parentPath, entry.name, 'package.json');
-		if (!existsSync(packageJsonPath)) continue;
-		const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-
-		packages.set(packageJson.name, packageJson.version);
-	}
-
-	return packages;
-});
+import { getPackageVersion } from '@/utils/package-versions';
 
 export interface Props {
 	pkgName: string;
@@ -39,26 +7,7 @@ export interface Props {
 
 const { pkgName } = Astro.props as Props;
 
-async function getVersion() {
-	if (localPackages.get().has(pkgName)) return localPackages.get().get(pkgName);
-
-	// Do not reach for NPM while in development
-	if (import.meta.env.DEV) return '0.0.0-dev';
-
-	const url = `https://registry.npmjs.org/${pkgName}/latest`;
-
-	const response = await simpleFetch(url);
-
-	if (!response.ok) {
-		throw new Error(
-			`npm API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(response.body)}`
-		);
-	}
-
-	return (response.body as { version: string }).version;
-}
-
-const version = await getVersion();
+const version = await getPackageVersion(pkgName);
 ---
 
 <span>v{version}</span>

--- a/docs/src/utils/package-versions.ts
+++ b/docs/src/utils/package-versions.ts
@@ -1,0 +1,60 @@
+import { Lazy } from '@inox-tools/utils/lazy';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { simpleFetch } from './fetch';
+
+type PackageInformation = {
+	name: string;
+	version: string;
+};
+
+const localPackages = Lazy.of(() => {
+	const packagesDir = new URL('packages/', import.meta.env.ASTRO_PROJECT_ROOT);
+	const entries = readdirSync(packagesDir, {
+		recursive: false,
+		encoding: 'utf-8',
+		withFileTypes: true,
+	});
+	const packages = new Map<string, PackageInformation>();
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+
+		const packageJsonPath = join(entry.parentPath, entry.name, 'package.json');
+		if (!existsSync(packageJsonPath)) continue;
+
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageInformation;
+
+		packages.set(packageJson.name, packageJson);
+	}
+
+	return packages;
+});
+
+export function getLocalPackageInformation(packageName: string) {
+	return localPackages.get().get(packageName);
+}
+
+export function isUnpublishedPackage(packageName: string) {
+	return getLocalPackageInformation(packageName)?.version === '0.0.0';
+}
+
+export async function getPackageVersion(packageName: string) {
+	const localPackage = getLocalPackageInformation(packageName);
+	if (localPackage) return localPackage.version;
+
+	// Do not reach for NPM while in development
+	if (import.meta.env.DEV) return '0.0.0-dev';
+
+	const url = `https://registry.npmjs.org/${packageName}/latest`;
+	const response = await simpleFetch(url);
+
+	if (!response.ok) {
+		throw new Error(
+			`npm API call failed: GET "${url}" returned status ${response.status}: ${JSON.stringify(response.body)}`
+		);
+	}
+
+	const packageInformation = response.body as Pick<PackageInformation, 'version'>;
+	return packageInformation.version;
+}


### PR DESCRIPTION
## Summary
- Automatically display an unpublished-package warning when a local package manifest has version `0.0.0`.
- Preserve Starlight frontmatter banners and style the custom warning with Starlight banner styles.
- Centralize local package metadata and version resolution for both the warning and `Version.astro`.

## Verification
- `pnpm --filter docs validate`
- `pnpm --filter docs build`
- `pnpm exec prettier --check docs/src/components/Banner.astro docs/src/components/Version.astro docs/src/utils/package-versions.ts`
- Rendered build output contains the warning only on `/every-astro` and `/git-redirect`.